### PR TITLE
github PR build permissions

### DIFF
--- a/.github/workflows/pr-package-json-comment.yml
+++ b/.github/workflows/pr-package-json-comment.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -42,6 +43,7 @@ jobs:
         if: steps.package-changes.outputs.changes_detected == 'true'
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 


### PR DESCRIPTION
Attempt to fix error on PRs, for when github workflow automatically adds comments on PR:
```
   data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/issues/comments#create-an-issue-comment',
      status: '403'
    }
    ...
    Error: Unhandled error: HttpError: Resource not accessible by integration
```

This is the fix suggested by @ivan-gudak
