### PR TITLE
[DO NOT MERGE]bump modelcontextprotocol version

### DIFF
--- a/.github/workflows/pr-package-json-comment.yml
+++ b/.github/workflows/pr-package-json-comment.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -42,6 +43,7 @@ jobs:
         if: steps.package-changes.outputs.changes_detected == 'true'
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@dynatrace/openkit-js": "^4.2.0",
-        "@modelcontextprotocol/sdk": "^1.21.2",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "axios": "^1.13.1",
         "commander": "^14.0.2",
         "open": "^8.4.2",
         "undici": "^7.16.0",
         "winston": "^3.18.3",
-        "zod-to-json-schema": "^3.24.6"
+        "zod-to-json-schema": "~3.25.0"
       },
       "bin": {
         "mcp-server-dynatrace": "dist/index.js"
@@ -1057,9 +1057,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.21.2.tgz",
-      "integrity": "sha512-HXR5NeVbaL45KuPRqfBQL/hcdc8Y197ALj5G75M5qUMcOk2at0bj2Nns4ZnjU2mTw52360TK63oDqvRjc1iPRQ==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
+      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -1071,20 +1071,25 @@
         "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1"
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "@cfworker/json-schema": {
           "optional": true
+        },
+        "zod": {
+          "optional": false
         }
       }
     },
@@ -4193,6 +4198,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
   "license": "MIT",
   "dependencies": {
     "@dynatrace/openkit-js": "^4.2.0",
-    "@modelcontextprotocol/sdk": "^1.21.2",
+    "@modelcontextprotocol/sdk": "^1.24.0",
     "axios": "^1.13.1",
     "commander": "^14.0.2",
     "open": "^8.4.2",
     "undici": "^7.16.0",
     "winston": "^3.18.3",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "~3.25.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ Never run queries that could return very large amounts of data, or that could be
     annotations: ToolAnnotations,
     cb: (args: z.objectOutputType<ZodRawShape, ZodTypeAny>) => Promise<string>,
   ) => {
-    const wrappedCb = async (args: ZodRawShape): Promise<CallToolResult> => {
+    const wrappedCb = async (args: any): Promise<CallToolResult> => {
       // Capture starttime for telemetry and rate limiting
       const startTime = Date.now();
 
@@ -283,7 +283,7 @@ Never run queries that could return very large amounts of data, or that could be
       }
     };
 
-    server.tool(name, description, paramsSchema, annotations, (args: z.ZodRawShape) => wrappedCb(args));
+    server.registerTool(name, { description: description }, (args: any) => wrappedCb(args));
   };
 
   tool(


### PR DESCRIPTION
To replace https://github.com/dynatrace-oss/dynatrace-managed-mcp/pull/4

**WARNING: DO NOT MERGE. This change does not work correctly; it does not handle the MCP tool parameters. Initial attempts to fix this, to do it the same way as the SaaS dynatrace-mcp, have not yet worked.**

Just bumping the version results in compilation failures. Need the additional code changes for it to work with the new type system. These are pretty-much the same changes as were done in the Dynatrace SaaS MCP (unfortunately fix involves using `any`). The code change here does go slightly beyond the Dynatrace SaaS code though, as `server.tool` is deprecated so we also update that to use `server.registerTool` instead.

Note: includes the change in https://github.com/dynatrace-oss/dynatrace-managed-mcp/pull/11, to test if that fix works (for github workflow to comment on the PR when package.json is being changed).