### PR TITLE
fix: Update server schema to 11-12-2025 to fix release

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dynatrace-oss/Dynatrace-Managed-MCP",
   "description": "Model Context Protocol (MCP) server for Dynatrace Managed (on-premise). Access logs, events, metrics from Dynatrace via MCP.",
   "repository": {


### PR DESCRIPTION
MCP catalog in dockerhub no longer accepts schema in version from 17.10.2025. 