### PR TITLE
Multi-environment support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,24 @@
 ## Dynatrace Managed Configuration
-# DT_MANAGED_ENVIRONMENT=01234567-89ab-cdef-abcd-ef0123456789
-# DT_API_ENDPOINT_URL=https://abc123.dynatrace-managed.example.com:9999
-# DT_DYNATRACE_URL=https://dmz123.dynatrace-managed.example.com
-# DT_MANAGED_API_TOKEN=dt0s16.SAMPLE.abcd1234
+# Proxy configuration optional (for corporate environments)
+# Mandatory keys are: "apiEndpointUrl", "environmentId", "alias" and "apiToken"
 
-# Proxy configuration (optional - for corporate environments)
-# HTTPS_PROXY=http://proxy.example.com:8080
+DT_ENVIRONMENT_CONFIGS='[
+  {
+    "dynatraceUrl": "https://my-dashboard-endpoint.com/",
+    "apiEndpointUrl": "https://my-api-endpoint.com/",
+    "environmentId": "my-env-id-1",
+    "alias": "alias-env",
+    "apiToken": "my-api-token",
+    "httpProxyUrl": "",
+    "httpsProxyUrl": ""
+  },
+  {
+    "dynatraceUrl": "https://my-dashboard2-endpoint.com/",
+    "apiEndpointUrl": "https://my-api2-endpoint.com/",
+    "environmentId": "my-env-id-2",
+    "alias": "alias-env-2",
+    "apiToken": "my-api-token-2",
+    "httpProxyUrl": "",
+    "httpsProxyUrl": ""
+  }
+]'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ If you would like to use encryption for your message, please first reach out to 
 
 ### When Should I NOT Report a Vulnerability?
 
-- You need help tuning one of our our Open Source projects for security - please discuss this with the maintainers of said project
+- You need help tuning one of our Open Source projects for security - please discuss this with the maintainers of said project
 - You need help applying security-related updates
 - Your issue is not security-related
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,11 +28,11 @@ API responses, and the response text returned by the MCP tool. Also check the lo
 
 ### Integration Tests
 
-Integration tests run against a real Dynatrace Managed environment, making real API calls.
+Integration tests run against a real Dynatrace Managed environment with alias set to `testAlias`, making real API calls.
 It is assumed that this environment has sufficient data to be able to sensibly test the API
-calls and processing of responses.
+calls and processing of responses. A second environment with alias `invalidApiToken` needs to be set up, with working credentials but a wrong apiToken, used to check error responses.
 
-Configure the `.env` file with the URL and [an API token with the required scopes](../README.md#api-scopes-for-managed-deployment). See `.env.template` as a starting point.
+Configure both environments in the `.env` file with the URL and [an API token with the required scopes](../README.md#api-scopes-for-managed-deployment). See `.env.template` as a starting point.
 See [main README](../README.md#environment-variables) for description of Environment Variables.
 
 Some useful example testing commands:
@@ -90,10 +90,7 @@ Configure your preferred AI Assistant with an mcp.json file like that below:
       "command": "npx",
       "args": ["--watch", "/path/to/repos/dynatrace-oss/dynatrace-manage-mcp/dist/index.js"],
       "env": {
-        "DT_MANAGED_ENVIRONMENT": "01234567-89ab-cdef-abcd-ef0123456789",
-        "DT_API_ENDPOINT_URL": "https://abc123.dynatrace-managed.example.com:9999",
-        "DT_DYNATRACE_URL": "https://dmz123.dynatrace-managed.example.com",
-        "DT_MANAGED_API_TOKEN": "dt0s16.SAMPLE.abcd1234",
+        "DT_ENVIRONMENT_CONFIGS": "[{\"dynatraceUrl\":\"https://my-dashboard-endpoint.com/\",\"apiEndpointUrl\":\"https://my-api-endpoint.com/\",\"environmentId\":\"my-env-id-1\",\"alias\":\"alias-env\",\"apiToken\":\"my-api-token\"},{\"dynatraceUrl\":\"https://my-dashboard2-endpoint.com/\",\"apiEndpointUrl\":\"https://my-api2-endpoint.com/\",\"environmentId\":\"my-env-id-2\",\"alias\":\"alias-env-2\",\"apiToken\":\"my-api-token-2\"}]",
         "DT_MCP_DISABLE_TELEMETRY": "true",
         "LOG_LEVEL": "debug"
       }
@@ -143,13 +140,7 @@ You can then use that locally, for example with the following in your `mcp.json`
         "--rm",
         "-i",
         "-e",
-        "DT_MANAGED_ENVIRONMENT",
-        "-e",
-        "DT_API_ENDPOINT_URL",
-        "-e",
-        "DT_DYNATRACE_URL",
-        "-e",
-        "DT_MANAGED_API_TOKEN",
+        "DT_ENVIRONMENT_CONFIGS",
         "-e",
         "DT_MCP_DISABLE_TELEMETRY",
         "-e",
@@ -157,10 +148,7 @@ You can then use that locally, for example with the following in your `mcp.json`
         "mcp/dynatrace-managed-mcp-server:snapshot"
       ],
       "env": {
-        "DT_MANAGED_ENVIRONMENT": "01234567-89ab-cdef-abcd-ef0123456789",
-        "DT_API_ENDPOINT_URL": "https://abc123.dynatrace-managed.example.com:9999",
-        "DT_DYNATRACE_URL": "https://dmz123.dynatrace-managed.example.com",
-        "DT_MANAGED_API_TOKEN": "dt0s16.SAMPLE.abcd1234"
+        "DT_ENVIRONMENT_CONFIGS": "[{\"dynatraceUrl\":\"https://my-dashboard-endpoint.com/\",\"apiEndpointUrl\":\"https://my-api-endpoint.com/\",\"environmentId\":\"my-env-id-1\",\"alias\":\"alias-env\",\"apiToken\":\"my-api-token\"},{\"dynatraceUrl\":\"https://my-dashboard2-endpoint.com/\",\"apiEndpointUrl\":\"https://my-api2-endpoint.com/\",\"environmentId\":\"my-env-id-2\",\"alias\":\"alias-env-2\",\"apiToken\":\"my-api-token-2\"}]",
         "DT_MCP_DISABLE_TELEMETRY": "true",
         "LOG_LEVEL": "debug"
       },

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,16 @@ What performance metrics are available for the books service
 Ask Dynatrace for the daily trend of the "builtin:service.response.time" metric for the dt_books_storage service over the last week
 ```
 
+### Example - Multienvironment
+
+```text
+Ask Dynatrace to list the open problems from all of my environments
+```
+
+```text
+Ask Dynatrace to list the open problems from my production environment
+```
+
 ### Example - Misc.
 
 ```text

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
       testEnvironment: 'node',
       testMatch: ['<rootDir>/integration-tests/**/*.integration.test.ts', '<rootDir>/tests/**/*.integration.test.ts'],
       testTimeout: 30000,
+      setupFiles: ['dotenv/config'],
     },
   ],
 };

--- a/server.json
+++ b/server.json
@@ -19,38 +19,14 @@
       },
       "environmentVariables": [
         {
-          "name": "DT_MANAGED_ENVIRONMENT",
-          "description": "id of the managed environment, used for constructing URL for API and dashboards (e.g. of the form `01234567-89ab-cdef-abcd-ef0123456789`)",
-          "isRequired": true,
-          "format": "string"
-        },
-        {
-          "name": "DT_API_ENDPOINT_URL",
-          "description": "base url for Dynatrace Managed API, to which the environment id will be appended (e.g. `https://abc123.dynatrace-managed.com:9999`)",
-          "isRequired": true,
-          "format": "string"
-        },
-        {
-          "name": "DT_DYNATRACE_URL",
-          "description": "base url for Dynatrace Managed dashboard, to which the environment id will be appended (e.g. `https://dmz123.dynatrace-managed.com`)",
-          "isRequired": false,
-          "format": "string"
-        },
-        {
-          "name": "DT_MANAGED_API_TOKEN",
-          "description": "API Token with required scopes (e.g. 'dt0s16.SAMPLE.abcd1234')",
+          "name": "DT_ENVIRONMENT_CONFIGS",
+          "description": "An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to. See README file for contents of this.",
           "isRequired": true,
           "format": "string"
         },
         {
           "name": "LOG_LEVEL",
           "description": "Logging level (e.g. debug, info, warning, error)",
-          "isRequired": false,
-          "format": "string"
-        },
-        {
-          "name": "HTTP_PROXY",
-          "description": "HTTP Proxy to use",
           "isRequired": false,
           "format": "string"
         },

--- a/src/authentication/__tests__/managed-auth-client.test.ts
+++ b/src/authentication/__tests__/managed-auth-client.test.ts
@@ -17,6 +17,8 @@ describe('ManagedAuthClient', () => {
       apiBaseUrl: 'https://managed.test.com',
       dashboardBaseUrl: 'https://managed-dashboard.test.com',
       apiToken: 'test-token',
+      alias: 'testAlias',
+      minimum_version: '1.328.0',
     });
   });
 
@@ -50,6 +52,8 @@ describe('ManagedAuthClient', () => {
         apiBaseUrl: 'https://managed.test.com',
         dashboardBaseUrl: 'https://managed-dashboard.test.com',
         apiToken: 'test-token',
+        alias: 'testAlias',
+        minimum_version: '1.328.0',
       });
 
       const result = await client.validateConnection();

--- a/src/authentication/__tests__/proxy.test.ts
+++ b/src/authentication/__tests__/proxy.test.ts
@@ -1,4 +1,4 @@
-import { getAxiosProxyFromEnv } from '../managed-auth-client';
+import { setAxiosProxy } from '../managed-auth-client';
 
 // Mock undici
 describe('proxy-config', () => {
@@ -21,7 +21,7 @@ describe('proxy-config', () => {
   describe('configureProxyFromEnvironment', () => {
     it('should parse HTTP_PROXY', () => {
       process.env.HTTP_PROXY = 'http://myhost.com:1234';
-      const response = getAxiosProxyFromEnv();
+      const response = setAxiosProxy(process.env.HTTP_PROXY);
 
       expect(response).toEqual({
         host: 'myhost.com',
@@ -33,7 +33,7 @@ describe('proxy-config', () => {
 
     it('should parse HTTPS_PROXY', () => {
       process.env.HTTPS_PROXY = 'https://myhost.com:1234';
-      const response = getAxiosProxyFromEnv();
+      const response = setAxiosProxy(process.env.HTTPS_PROXY);
 
       expect(response).toEqual({
         host: 'myhost.com',
@@ -45,7 +45,7 @@ describe('proxy-config', () => {
 
     it('should parse auth', () => {
       process.env.HTTP_PROXY = 'http://myuser:mypass@myhost.com:1234';
-      const response = getAxiosProxyFromEnv();
+      const response = setAxiosProxy(process.env.HTTP_PROXY);
 
       expect(response).toEqual({
         host: 'myhost.com',
@@ -56,25 +56,22 @@ describe('proxy-config', () => {
     });
 
     it('should return undefined if no proxy', () => {
-      const response = getAxiosProxyFromEnv();
+      const response = setAxiosProxy();
       expect(response).toBeUndefined();
     });
 
-    it('should fail if set HTTP_PROXY and HTTPS_PROXY', () => {
+    it('should return undefined if set HTTP_PROXY and HTTPS_PROXY', () => {
       process.env.HTTP_PROXY = 'http://myuser:mypass@myhost.com:1234';
       process.env.HTTPS_PROXY = 'https://myuser:mypass@myhost.com:4321';
-      try {
-        const response = getAxiosProxyFromEnv();
-        fail(`Should have failed, but returned response=${response}`);
-      } catch (err: any) {
-        expect(err.message).toContain('Cannot specify both HTTPS_PROXY and HTTP_PROXY, use only one');
-      }
+
+      const response = setAxiosProxy();
+      expect(response).toBeUndefined();
     });
 
     it('should fail if invalid URL', () => {
       process.env.HTTP_PROXY = 'this is not a url';
       try {
-        const response = getAxiosProxyFromEnv();
+        const response = setAxiosProxy(process.env.HTTP_PROXY);
         fail(`Should have failed, but returned response=${response}`);
       } catch (err: any) {
         expect(err.message).toContain('Failed to parse and configure http(s) proxy');

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -1,5 +1,17 @@
 import axios, { AxiosInstance, AxiosProxyConfig } from 'axios';
 import { logger } from '../utils/logger';
+import { ManagedEnvironmentConfig } from '../utils/environment';
+
+const MANAGED_API_SCOPES = [
+  'DataExport', // Read metrics and topology
+  'ReadConfig', // Read configuration and cluster version
+  'ReadSyntheticData', // Read synthetic monitoring data
+  'ReadLogContent', // Read log content
+  'ReadEvents', // Read events
+  'ReadProblems', // Read problems and root cause analysis
+  'ReadSecurityProblems', // Read security problems
+  'ReadSLO', // Read Service Level Objectives
+];
 
 export interface ClusterVersion {
   version: string;
@@ -9,20 +21,90 @@ export interface ManagedAuthClientParams {
   apiBaseUrl: string;
   dashboardBaseUrl: string;
   apiToken: string;
+  alias: string;
+  httpProxy?: string;
+  httpsProxy?: string;
+  isValid?: boolean;
+  minimum_version: string;
+}
+
+export class ManagedAuthClientManager {
+  public readonly rawClients: ManagedAuthClient[];
+  public clients: ManagedAuthClient[];
+  public validAliases: string[] = [];
+  public readonly MINIMUM_VERSION = '1.328.0';
+
+  constructor(managedEnvironments: ManagedEnvironmentConfig[]) {
+    this.rawClients = [];
+    this.clients = [];
+    this.validAliases = ['ALL_ENVIRONMENTS'];
+
+    logger.warn('Validating Environments');
+    for (let managedEnvironment of managedEnvironments) {
+      let newClient = new ManagedAuthClient({
+        apiBaseUrl: managedEnvironment.apiUrl,
+        dashboardBaseUrl: managedEnvironment.dashboardUrl,
+        apiToken: managedEnvironment.apiToken,
+        alias: managedEnvironment.alias,
+        httpProxy: managedEnvironment.httpProxy,
+        httpsProxy: managedEnvironment.httpsProxy,
+        minimum_version: this.MINIMUM_VERSION,
+      });
+      this.rawClients.push(newClient);
+    }
+  }
+
+  async makeRequests(endpoint: string, params: Record<string, any>, environments: string): Promise<Map<string, any>> {
+    const selectedAliases = environments === 'ALL_ENVIRONMENTS' ? this.validAliases : environments.split(';');
+    let responses = new Map<string, any>();
+    for (const client of this.clients) {
+      if (selectedAliases.indexOf(client.alias) > -1) {
+        const response = await client.makeRequest(endpoint, params);
+        responses.set(client.alias, response);
+      }
+    }
+    return responses;
+  }
+
+  async isConfigured(): Promise<void> {
+    for (let client of this.rawClients) {
+      let validClient = await client.isConfigured();
+      if (validClient) {
+        client.isValid = true;
+        this.clients.push(client);
+        this.validAliases.push(client.alias);
+      }
+    }
+  }
+
+  getBaseUrl(alias: string): string {
+    for (let client of this.clients) {
+      if (client.alias === alias) {
+        return client.dashboardBaseUrl;
+      }
+    }
+    return '';
+  }
 }
 
 export class ManagedAuthClient {
   public apiBaseUrl: string;
   public dashboardBaseUrl: string;
+  public alias: string;
+  public isValid: boolean;
+  public validationError: string;
   private proxy: AxiosProxyConfig | undefined;
   private httpClient: AxiosInstance;
-  public readonly MINIMUM_VERSION = '1.328.0';
+  public MINIMUM_VERSION: string;
 
   constructor(params: ManagedAuthClientParams) {
     this.apiBaseUrl = params.apiBaseUrl;
     this.dashboardBaseUrl = params.dashboardBaseUrl;
-
-    this.proxy = getAxiosProxyFromEnv();
+    this.alias = params.alias;
+    this.proxy = setAxiosProxy(params.httpProxy, params.httpsProxy);
+    this.isValid = params.isValid ? params.isValid : false;
+    this.MINIMUM_VERSION = params.minimum_version;
+    this.validationError = '';
 
     this.httpClient = axios.create({
       baseURL: this.apiBaseUrl,
@@ -42,13 +124,16 @@ export class ManagedAuthClient {
       const response = await this.httpClient.get('/api/v1/config/clusterversion');
       return response.status === 200;
     } catch (error) {
-      logger.error('Failed calling /api/v1/config/clusterversion; falling back to /api/v2/metrics', { error: error });
+      logger.error(
+        `[Alias: ${this.alias}] Failed calling /api/v1/config/clusterversion; falling back to /api/v2/metrics`,
+        { error: error },
+      );
       // Fallback: try a basic API endpoint that exists in both SaaS and Managed
       try {
         const response = await this.httpClient.get('/api/v2/metrics', { params: { pageSize: 1 } });
         return response.status === 200;
       } catch (fallbackError) {
-        logger.error('Failed calling /api/v2/metrics', { error: fallbackError });
+        logger.error(`[Alias: ${this.alias}] Failed calling /api/v2/metrics`, { error: fallbackError });
         return false;
       }
     }
@@ -78,10 +163,6 @@ export class ManagedAuthClient {
     return true; // Equal versions
   }
 
-  getHttpClient(): AxiosInstance {
-    return this.httpClient;
-  }
-
   cleanup(): void {
     // Destroy the axios instance to close connections
     if (this.httpClient) {
@@ -99,21 +180,57 @@ export class ManagedAuthClient {
 
   async makeRequest(endpoint: string, params?: Record<string, any>): Promise<any> {
     const url = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
-
     const response = await this.httpClient.get(url, {
       proxy: this.proxy ?? undefined,
       params: params || {},
     });
     return response.data;
   }
+
+  async isConfigured() {
+    // Test connection to Managed cluster
+    logger.info(`Testing connection to Dynatrace Managed environment "${this.alias}": ${this.apiBaseUrl}...`);
+    try {
+      const isConnected = await this.validateConnection();
+      if (!isConnected) {
+        //throw new Error('Connection validation failed'); // CANT CONNECT
+        this.validationError = "Connection validation failed: Can't connect to environment " + this.alias;
+        return false;
+      }
+      logger.info(`Called validateConnection`);
+
+      const clusterVersion = await this.getClusterVersion();
+      logger.info(`Connected to Managed cluster version ${clusterVersion.version}`);
+
+      const isValidVersion = this.validateMinimumVersion(clusterVersion);
+      if (!isValidVersion) {
+        const invalidVersionMessage = `Environment "${this.alias}" version ${clusterVersion.version} may not support all features. Minimum recommended version is ${this.MINIMUM_VERSION}`;
+        logger.info(invalidVersionMessage);
+        this.validationError = invalidVersionMessage;
+        return false;
+      }
+      return true;
+    } catch (error: any) {
+      logger.error(
+        `[CONNECTION ERROR] Failed to connect to Managed environment "${this.alias}": ${this.apiBaseUrl}: ${error.message}.`,
+      );
+      logger.error('Please verify:');
+      logger.error('1. DT_ENVIRONMENT_CONFIGS is correct');
+      logger.error(`2. API Token has required scopes: ${MANAGED_API_SCOPES.join(', ')}`);
+      logger.error('3. Network connectivity to the Managed environment');
+      this.validationError = `Failed to connect to Managed environment "${this.alias}": ${this.apiBaseUrl}: ${error.message}. Please verify connection details are correct.`;
+      return false;
+    }
+  }
 }
 
-export function getAxiosProxyFromEnv(): AxiosProxyConfig | undefined {
-  const httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
-  const httpProxy = process.env.http_proxy || process.env.HTTP_PROXY;
-
+export function setAxiosProxy(httpProxy = '', httpsProxy = ''): AxiosProxyConfig | undefined {
   if (httpsProxy && httpProxy) {
-    throw Error('Cannot specify both HTTPS_PROXY and HTTP_PROXY, use only one.');
+    logger.error('Cannot specify both HTTPS_PROXY and HTTP_PROXY, use only one.');
+    return undefined;
+  } else if (!httpsProxy && !httpProxy) {
+    // No proxy configured, nothing to do
+    return undefined;
   }
 
   try {

--- a/src/capabilities/__tests__/entities-api.test.ts
+++ b/src/capabilities/__tests__/entities-api.test.ts
@@ -1,18 +1,21 @@
 import { EntitiesApiClient, Entity, GetEntityRelationshipsResponse } from '../entities-api';
-import { ManagedAuthClient } from '../../authentication/managed-auth-client';
+import { ManagedAuthClientManager } from '../../authentication/managed-auth-client';
 import { readFileSync } from 'fs';
 
 jest.mock('../../authentication/managed-auth-client');
 
 describe('EntitiesApiClient', () => {
-  let mockAuthClient: jest.Mocked<ManagedAuthClient>;
+  let mockAuthManager: jest.Mocked<ManagedAuthClientManager>;
   let client: EntitiesApiClient;
 
   beforeEach(() => {
-    mockAuthClient = {
-      makeRequest: jest.fn(),
+    mockAuthManager = {
+      makeRequests: jest.fn(),
+      getBaseUrl: jest.fn(() => {
+        return 'http://dashboardbaseurl.com/e/environment_id';
+      }),
     } as any;
-    client = new EntitiesApiClient(mockAuthClient);
+    client = new EntitiesApiClient(mockAuthManager);
   });
 
   afterEach(() => {
@@ -21,39 +24,43 @@ describe('EntitiesApiClient', () => {
 
   describe('getEntityDetails', () => {
     it('should get entity details by ID', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+      const result = await client.getEntityDetails('SERVICE-123', 'testAlias');
 
-      const result = await client.getEntityDetails('SERVICE-123');
-
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/entities/SERVICE-123');
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith('/api/v2/entities/SERVICE-123', {}, 'testAlias');
       expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getEntityRelationships', () => {
     it('should get entity relationships', async () => {
-      const mockEntity: Entity = {
-        entityId: 'SERVICE-123',
-        displayName: 'payment-service',
-        entityType: 'SERVICE',
-        fromRelationships: [
+      const mockEntity = new Map<string, any>([
+        [
+          'testAlias',
           {
-            id: 'rel-1',
-            type: 'CALLS',
-            fromEntityId: 'SERVICE-123',
-            toEntityId: 'SERVICE-456',
+            entityId: 'SERVICE-123',
+            displayName: 'payment-service',
+            entityType: 'SERVICE',
+            fromRelationships: [
+              {
+                id: 'rel-1',
+                type: 'CALLS',
+                fromEntityId: 'SERVICE-123',
+                toEntityId: 'SERVICE-456',
+              },
+            ],
+            toRelationships: [
+              {
+                id: 'rel-2',
+                type: 'RUNS_ON',
+                fromEntityId: 'SERVICE-123',
+                toEntityId: 'HOST-789',
+              },
+            ],
           },
         ],
-        toRelationships: [
-          {
-            id: 'rel-2',
-            type: 'RUNS_ON',
-            fromEntityId: 'SERVICE-123',
-            toEntityId: 'HOST-789',
-          },
-        ],
-      };
+      ]);
       const expectedResponse: GetEntityRelationshipsResponse = {
         entityId: 'SERVICE-123',
         fromRelationships: [
@@ -74,50 +81,48 @@ describe('EntitiesApiClient', () => {
         ],
       };
 
-      mockAuthClient.makeRequest.mockResolvedValue(mockEntity);
-
-      const result = await client.getEntityRelationships('SERVICE-123');
-
-      expect(result).toEqual(expectedResponse);
+      mockAuthManager.makeRequests.mockResolvedValue(mockEntity);
+      const result = await client.getEntityRelationships('SERVICE-123', 'testAlias');
+      expect(result.get('testAlias')).toEqual(expectedResponse);
     });
   });
 
   describe('formatEntityDetails', () => {
     it('should format details', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/getEntityDetails.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/getEntityDetails.json', 'utf8'))],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getEntityDetails('my-id');
+      const response = await client.getEntityDetails('my-id', 'testAlias');
       const result = client.formatEntityDetails(response);
 
-      expect(result).toContain('Entity details in the following json');
+      expect(result).toContain('Entity details from environment testAlias in the following json');
       expect(result).toContain('"type":"SERVICE"');
       expect(result).toContain('"displayName":"Service"');
     });
 
     it('should format details when sparse problem', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getEntityDetails('my-id');
+      const response = await client.getEntityDetails('my-id', 'testAlias');
       const result = client.formatEntityDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Entity details in the following json');
-      expect(result).toContain('{}');
+      expect(result).toContain('Entity details from environment testAlias in the following json');
+      expect(response.get('testAlias')).toEqual({});
     });
   });
 
   describe('formatEntityTypes', () => {
     it('should format list', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/listEntityTypes.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/listEntityTypes.json', 'utf8'))],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listEntityTypes();
+      const response = await client.listEntityTypes('ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeList(response);
 
       expect(result).toContain('Listing 1 of 2 entity types');
@@ -125,75 +130,94 @@ describe('EntitiesApiClient', () => {
     });
 
     it('should format list when sparse', async () => {
-      const mockResponse = {
-        types: [{}],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            types: [{}],
+          },
+        ],
+      ]);
 
-      const response = await client.listEntityTypes();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listEntityTypes('ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeList(response);
 
-      expect(result).toContain('Listing 1 entity types');
+      expect(result).toContain('Listing 1 entity types for environment testAlias');
       expect(result).toContain('undefined');
     });
 
     it('should format list when empty', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listEntityTypes();
+      const response = await client.listEntityTypes('ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeList(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Listing 0 entity types');
+      expect(result).toContain('Listing 0 entity types for environment testAlias');
     });
 
     it('should handle empty list', async () => {
-      const mockResponse = {
-        totalCount: 0,
-        types: [],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 0,
+            types: [],
+          },
+        ],
+      ]);
 
-      const response = await client.listEntityTypes();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listEntityTypes('ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeList(response);
-      expect(result).toContain('Listing 0 entity types');
+      expect(result).toContain('Listing 0 entity types for environment testAlias');
     });
   });
 
   describe('formatEntityTypeDetails', () => {
     it('should format details', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/getEntityTypeDetails.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          JSON.parse(readFileSync('src/capabilities/__tests__/resources/getEntityTypeDetails.json', 'utf8')),
+        ],
+      ]);
 
-      const response = await client.getEntityTypeDetails('SERVICE');
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.getEntityTypeDetails('SERVICE', 'ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeDetails(response);
 
-      expect(result).toContain('Entity type details in the following json');
+      expect(result).toContain('Entity type details from environment testAlias in the following json');
       expect(result).toContain('"displayName":"ActiveGate"');
       expect(result).toContain('"type":"APM_SECURITY_GATEWAY"');
     });
 
     it('should format list when sparse', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getEntityTypeDetails('SERVICE');
+      const response = await client.getEntityTypeDetails('SERVICE', 'ALL_ENVIRONMENTS');
       const result = client.formatEntityTypeDetails(response);
 
-      expect(result).toContain('Entity type details in the following json');
+      expect(result).toContain('Entity type details from environment testAlias in the following json');
       expect(result).toContain('{}');
     });
   });
 
   describe('formatEntityList', () => {
     it('should format list', async () => {
-      const mockResponse = JSON.parse(readFileSync('src/capabilities/__tests__/resources/queryEntities.json', 'utf8'));
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/queryEntities.json', 'utf8'))],
+      ]);
 
-      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' });
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' }, 'ALL_ENVIRONMENTS');
       const result = client.formatEntityList(response);
 
       expect(response).toEqual(mockResponse);
@@ -211,13 +235,19 @@ describe('EntitiesApiClient', () => {
         entityType: 'SERVICE',
         tags: [{ context: 'CONTEXTLESS', key: 'environment', value: 'production' }],
       }));
-      const mockResponse = {
-        totalCount: 100,
-        entities: mockEntities,
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 100,
+            entities: mockEntities,
+          },
+        ],
+      ]);
 
-      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' });
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' }, 'ALL_ENVIRONMENTS');
       const result = client.formatEntityList(response);
 
       // Should show all 60 entities, not just 20
@@ -227,22 +257,27 @@ describe('EntitiesApiClient', () => {
     });
 
     it('should handle empty entities list', async () => {
-      const mockResponse = {
-        totalCount: 0,
-        entities: [],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 0,
+            entities: [],
+          },
+        ],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' });
+      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' }, 'ALL_ENVIRONMENTS');
       const result = client.formatEntityList(response);
       expect(result).toContain('Listing 0 entities');
     });
 
     it('should handle entities list that is empty', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' });
+      const response = await client.queryEntities({ entitySelector: 'type(SERVICE)' }, 'ALL_ENVIRONMENTS');
       const result = client.formatEntityList(response);
       expect(result).toContain('Listing 0 entities');
     });
@@ -250,27 +285,33 @@ describe('EntitiesApiClient', () => {
 
   describe('formatEntityRelationships', () => {
     it('should format entity relationships', async () => {
-      const mockEntity: Entity = {
-        entityId: 'SERVICE-123',
-        displayName: 'payment-service',
-        entityType: 'SERVICE',
-        fromRelationships: [
+      const mockEntity = new Map<string, any>([
+        [
+          'testAlias',
           {
-            id: 'rel-1',
-            type: 'CALLS',
-            fromEntityId: 'SERVICE-123',
-            toEntityId: 'SERVICE-456',
+            entityId: 'SERVICE-123',
+            displayName: 'payment-service',
+            entityType: 'SERVICE',
+            fromRelationships: [
+              {
+                id: 'rel-1',
+                type: 'CALLS',
+                fromEntityId: 'SERVICE-123',
+                toEntityId: 'SERVICE-456',
+              },
+            ],
+            toRelationships: [
+              {
+                id: 'rel-2',
+                type: 'RUNS_ON',
+                fromEntityId: 'SERVICE-123',
+                toEntityId: 'HOST-789',
+              },
+            ],
           },
         ],
-        toRelationships: [
-          {
-            id: 'rel-2',
-            type: 'RUNS_ON',
-            fromEntityId: 'SERVICE-123',
-            toEntityId: 'HOST-789',
-          },
-        ],
-      };
+      ]);
+
       const expectedResponse: GetEntityRelationshipsResponse = {
         entityId: 'SERVICE-123',
         fromRelationships: [
@@ -291,12 +332,12 @@ describe('EntitiesApiClient', () => {
         ],
       };
 
-      mockAuthClient.makeRequest.mockResolvedValue(mockEntity);
+      mockAuthManager.makeRequests.mockResolvedValue(mockEntity);
 
-      const response = await client.getEntityRelationships('SERVICE-123');
+      const response = await client.getEntityRelationships('SERVICE-123', 'testAlias');
       const result = client.formatEntityRelationships(response);
 
-      expect(response).toEqual(expectedResponse);
+      expect(response.get('testAlias')).toEqual(expectedResponse);
       expect(result).toContain('Found 1 fromRelationship');
       expect(result).toContain('"id":"rel-1"');
       expect(result).toContain('Found 1 toRelationship');
@@ -304,57 +345,74 @@ describe('EntitiesApiClient', () => {
     });
 
     it('should return empty array when no relationships exist', async () => {
-      const mockEntity: Entity = {
-        entityId: 'SERVICE-123',
-        displayName: 'isolated-service',
-        entityType: 'SERVICE',
-      };
+      const mockEntity = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            entityId: 'SERVICE-123',
+            displayName: 'isolated-service',
+            entityType: 'SERVICE',
+          },
+        ],
+      ]);
+
       const expectedResponse: GetEntityRelationshipsResponse = {
         entityId: 'SERVICE-123',
         fromRelationships: undefined,
         toRelationships: undefined,
       };
 
-      mockAuthClient.makeRequest.mockResolvedValue(mockEntity);
+      mockAuthManager.makeRequests.mockResolvedValue(mockEntity);
 
-      const response = await client.getEntityRelationships('SERVICE-123');
+      const response = await client.getEntityRelationships('SERVICE-123', 'testAlias');
       const result = client.formatEntityRelationships(response);
 
-      expect(response).toEqual(expectedResponse);
+      expect(response.get('testAlias')).toEqual(expectedResponse);
       expect(result).toContain('No relationships found for entity SERVICE-123');
     });
 
     it('should handle null relationships without error', async () => {
-      const mockEntity = {
-        entityId: 'SERVICE-123',
-        displayName: 'service-with-undefined-relationships',
-        entityType: 'SERVICE',
-        fromRelationships: null,
-        toRelationships: null,
-      };
+      const mockEntity = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            entityId: 'SERVICE-123',
+            displayName: 'service-with-undefined-relationships',
+            entityType: 'SERVICE',
+            fromRelationships: null,
+            toRelationships: null,
+          },
+        ],
+      ]);
       const expectedResponse = {
         entityId: 'SERVICE-123',
         fromRelationships: null,
         toRelationships: null,
       };
 
-      mockAuthClient.makeRequest.mockResolvedValue(mockEntity);
+      mockAuthManager.makeRequests.mockResolvedValue(mockEntity);
 
-      const response = await client.getEntityRelationships('SERVICE-123');
+      const response = await client.getEntityRelationships('SERVICE-123', 'testAlias');
       const result = client.formatEntityRelationships(response);
 
-      expect(response).toEqual(expectedResponse);
+      expect(response.get('testAlias')).toEqual(expectedResponse);
       expect(result).toContain('No relationships found for entity SERVICE-123');
     });
 
     it('should handle non-array relationships without error', async () => {
-      const mockEntity: any = {
-        entityId: 'SERVICE-123',
-        displayName: 'service-with-invalid-relationships',
-        entityType: 'SERVICE',
-        fromRelationships: 'not-an-array',
-        toRelationships: { unexpectedKey: 'unexpected-val' },
-      };
+      const mockEntity = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            entityId: 'SERVICE-123',
+            displayName: 'service-with-invalid-relationships',
+            entityType: 'SERVICE',
+            fromRelationships: 'not-an-array',
+            toRelationships: { unexpectedKey: 'unexpected-val' },
+          },
+        ],
+      ]);
+
       const expectedResponse = {
         entityId: 'SERVICE-123',
         fromRelationships: 'not-an-array',
@@ -362,12 +420,12 @@ describe('EntitiesApiClient', () => {
       };
       // { fromRelationships: 'not-an-array', toRelationships: { invalid: 'object' } }
 
-      mockAuthClient.makeRequest.mockResolvedValue(mockEntity);
+      mockAuthManager.makeRequests.mockResolvedValue(mockEntity);
 
-      const response = await client.getEntityRelationships('SERVICE-123');
+      const response = await client.getEntityRelationships('SERVICE-123', 'testAlias');
       const result = client.formatEntityRelationships(response);
 
-      expect(response).toEqual(expectedResponse);
+      expect(response.get('testAlias')).toEqual(expectedResponse);
       expect(result).toContain('Found 1 fromRelationship');
       expect(result).toContain('not-an-array');
       expect(result).toContain('Found 1 toRelationship');
@@ -377,26 +435,33 @@ describe('EntitiesApiClient', () => {
 
   describe('queryEntities', () => {
     it('should query entities by entitySelector', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.queryEntities({
-        entitySelector: 'type(SERVICE)',
-        pageSize: 12,
-        mzSelector: 'mzId(123,456)',
-        from: 'now-1h',
-        to: 'now',
-        sort: '-timestamp',
-      });
+      const result = await client.queryEntities(
+        {
+          entitySelector: 'type(SERVICE)',
+          pageSize: 12,
+          mzSelector: 'mzId(123,456)',
+          from: 'now-1h',
+          to: 'now',
+          sort: '-timestamp',
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/entities', {
-        entitySelector: 'type(SERVICE)',
-        pageSize: 12,
-        mzSelector: 'mzId(123,456)',
-        from: 'now-1h',
-        to: 'now',
-        sort: '-timestamp',
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/entities',
+        {
+          entitySelector: 'type(SERVICE)',
+          pageSize: 12,
+          mzSelector: 'mzId(123,456)',
+          from: 'now-1h',
+          to: 'now',
+          sort: '-timestamp',
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
   });

--- a/src/capabilities/__tests__/problems-api.test.ts
+++ b/src/capabilities/__tests__/problems-api.test.ts
@@ -1,18 +1,21 @@
 import { ProblemsApiClient, Problem } from '../problems-api';
-import { ManagedAuthClient } from '../../authentication/managed-auth-client';
+import { ManagedAuthClientManager } from '../../authentication/managed-auth-client';
 import { readFileSync } from 'fs';
 
 jest.mock('../../authentication/managed-auth-client');
 
 describe('ProblemsApiClient', () => {
-  let mockAuthClient: jest.Mocked<ManagedAuthClient>;
+  let mockAuthManager: jest.Mocked<ManagedAuthClientManager>;
   let client: ProblemsApiClient;
 
   beforeEach(() => {
-    mockAuthClient = {
-      makeRequest: jest.fn(),
+    mockAuthManager = {
+      makeRequests: jest.fn(),
+      getBaseUrl: jest.fn(() => {
+        return 'http://dashboardbaseurl.com/e/environment_id';
+      }),
     } as any;
-    client = new ProblemsApiClient(mockAuthClient);
+    client = new ProblemsApiClient(mockAuthManager);
   });
 
   afterEach(() => {
@@ -21,60 +24,74 @@ describe('ProblemsApiClient', () => {
 
   describe('listProblems', () => {
     it('should list problems with all parameters', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue({});
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.listProblems({
-        from: 'now-24h',
-        to: 'now',
-        status: 'OPEN',
-        impactLevel: 'SERVICE',
-        pageSize: 25,
-        sort: '-startTime',
-      });
+      const result = await client.listProblems(
+        {
+          from: 'now-24h',
+          to: 'now',
+          status: 'OPEN',
+          impactLevel: 'SERVICE',
+          pageSize: 25,
+          sort: '-startTime',
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/problems', {
-        pageSize: 25,
-        from: 'now-24h',
-        to: 'now',
-        status: 'OPEN',
-        impactLevel: 'SERVICE',
-        sort: '-startTime',
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/problems',
+        {
+          pageSize: 25,
+          from: 'now-24h',
+          to: 'now',
+          status: 'OPEN',
+          impactLevel: 'SERVICE',
+          sort: '-startTime',
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
 
     it('should use default parameters when none provided', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.listProblems();
+      const result = await client.listProblems({}, 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/problems', {
-        pageSize: 50,
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/problems',
+        {
+          pageSize: 50,
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getProblemDetails', () => {
     it('should get problem details by ID', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.getProblemDetails('PROBLEM-123');
+      const result = await client.getProblemDetails('PROBLEM-123', 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/problems/PROBLEM-123');
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith('/api/v2/problems/PROBLEM-123', {}, 'testAlias');
       expect(result).toEqual(mockResponse);
     });
   });
 
   describe('formatList', () => {
     it('should format list', async () => {
-      const mockResponse = JSON.parse(readFileSync('src/capabilities/__tests__/resources/listProblems.json', 'utf8'));
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/listProblems.json', 'utf8'))],
+      ]);
 
-      const response = await client.listProblems();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listProblems({}, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -89,12 +106,11 @@ describe('ProblemsApiClient', () => {
     });
 
     it('should format list when sparse problem', async () => {
-      const mockResponse = {
-        problems: [{}],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', { problems: [{}] }]]);
 
-      const response = await client.listProblems();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listProblems({}, 'ALL_ENVIRONMENTS');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -109,10 +125,10 @@ describe('ProblemsApiClient', () => {
     });
 
     it('should format list when empty', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listProblems();
+      const response = await client.listProblems({}, 'ALL_ENVIRONMENTS');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -130,10 +146,16 @@ describe('ProblemsApiClient', () => {
         status: 'OPEN',
         startTime: 1640995200000 + i * 1000,
       }));
-      const response = {
-        totalCount: 123,
-        problems: mockProblems,
-      };
+
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 123,
+            problems: mockProblems,
+          },
+        ],
+      ]);
 
       const result = client.formatList(response);
 
@@ -144,10 +166,15 @@ describe('ProblemsApiClient', () => {
     });
 
     it('should handle empty list', () => {
-      const response = {
-        totalCount: 0,
-        problems: [],
-      };
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 0,
+            problems: [],
+          },
+        ],
+      ]);
       const result = client.formatList(response);
       expect(result).toContain('Listing 0 problems');
     });
@@ -155,29 +182,30 @@ describe('ProblemsApiClient', () => {
 
   describe('formatProblemDetails', () => {
     it('should format details', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/getProblemDetails.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/getProblemDetails.json', 'utf8'))],
+      ]);
 
-      const response = await client.getProblemDetails('845025139905093722_1763133360000V2');
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.getProblemDetails('845025139905093722_1763133360000V2', 'ALL_ENVIRONMENTS');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of problem in the following json');
+      expect(result).toContain('Details of problem from environment testAlias in the following json');
       expect(result).toContain('"problemId":"845025139905093722_1763133360000V2"');
       expect(result).toContain('"displayId":"P-2511153"');
     });
 
     it('should format details when sparse problem', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getProblemDetails('my-id');
+      const response = await client.getProblemDetails('my-id', 'ALL_ENVIRONMENTS');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of problem in the following json');
+      expect(result).toContain('Details of problem from environment testAlias in the following json');
       expect(result).toContain('{}');
     });
   });

--- a/src/capabilities/__tests__/security-api.test.ts
+++ b/src/capabilities/__tests__/security-api.test.ts
@@ -1,18 +1,21 @@
 import { SecurityApiClient, SecurityProblem } from '../security-api';
-import { ManagedAuthClient } from '../../authentication/managed-auth-client';
+import { ManagedAuthClientManager } from '../../authentication/managed-auth-client';
 import { readFileSync } from 'fs';
 
 jest.mock('../../authentication/managed-auth-client');
 
 describe('SecurityApiClient', () => {
-  let mockAuthClient: jest.Mocked<ManagedAuthClient>;
+  let mockAuthManager: jest.Mocked<ManagedAuthClientManager>;
   let client: SecurityApiClient;
 
   beforeEach(() => {
-    mockAuthClient = {
-      makeRequest: jest.fn(),
+    mockAuthManager = {
+      makeRequests: jest.fn(),
+      getBaseUrl: jest.fn(() => {
+        return 'http://dashboardbaseurl.com/e/environment_id';
+      }),
     } as any;
-    client = new SecurityApiClient(mockAuthClient);
+    client = new SecurityApiClient(mockAuthManager);
   });
 
   afterEach(() => {
@@ -21,49 +24,60 @@ describe('SecurityApiClient', () => {
 
   describe('listSecurityProblems', () => {
     it('should list security problems with default parameters', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.listSecurityProblems();
+      const result = await client.listSecurityProblems({}, 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/securityProblems', {
-        pageSize: SecurityApiClient.API_PAGE_SIZE,
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/securityProblems',
+        {
+          pageSize: SecurityApiClient.API_PAGE_SIZE,
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
 
     it('should list security problems with all parameters', async () => {
-      const mockResponse = { securityProblems: [] };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', { securityProblems: [] }]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      await client.listSecurityProblems({
-        riskLevel: 'LOW',
-        status: 'OPEN',
-        entitySelector: 'my-entity-selector',
-        from: 'my-from',
-        to: 'my-to',
-        pageSize: 12,
-        sort: 'my-sort',
-      });
+      await client.listSecurityProblems(
+        {
+          riskLevel: 'LOW',
+          status: 'OPEN',
+          entitySelector: 'my-entity-selector',
+          from: 'my-from',
+          to: 'my-to',
+          pageSize: 12,
+          sort: 'my-sort',
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/securityProblems', {
-        pageSize: 12,
-        riskLevel: 'LOW',
-        securityProblemSelector: 'status("OPEN")',
-        entitySelector: 'my-entity-selector',
-        from: 'my-from',
-        to: 'my-to',
-        sort: 'my-sort',
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/securityProblems',
+        {
+          pageSize: 12,
+          riskLevel: 'LOW',
+          securityProblemSelector: 'status("OPEN")',
+          entitySelector: 'my-entity-selector',
+          from: 'my-from',
+          to: 'my-to',
+          sort: 'my-sort',
+        },
+        'testAlias',
+      );
     });
 
     it('should handle API errors', async () => {
-      mockAuthClient.makeRequest.mockRejectedValue({
+      mockAuthManager.makeRequests.mockRejectedValue({
         response: { data: { message: 'Request failed with status code 404' } },
       });
 
       try {
-        await client.listSecurityProblems();
+        await client.listSecurityProblems({}, 'testAlias');
         fail('Should have propagated exception');
       } catch (error: any) {
         console.log(error);
@@ -74,24 +88,22 @@ describe('SecurityApiClient', () => {
 
   describe('getSecurityProblemDetails', () => {
     it('should get security problem details', async () => {
-      const mockResponse = {
-        securityProblemId: 'SP-123',
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', { securityProblemId: 'SP-123' }]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.getSecurityProblemDetails('SP-123');
+      const result = await client.getSecurityProblemDetails('SP-123', 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/securityProblems/SP-123');
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith('/api/v2/securityProblems/SP-123', {}, 'testAlias');
       expect(result).toEqual(mockResponse);
     });
 
     it('should handle API errors', async () => {
-      mockAuthClient.makeRequest.mockRejectedValue({
+      mockAuthManager.makeRequests.mockRejectedValue({
         response: { data: { message: 'Request failed with status code 404' } },
       });
 
       try {
-        await client.getSecurityProblemDetails('SP-999');
+        await client.getSecurityProblemDetails('SP-999', 'testAlias');
         fail('Should have propagated exception');
       } catch (error: any) {
         console.log(error);
@@ -102,12 +114,15 @@ describe('SecurityApiClient', () => {
 
   describe('formatList', () => {
     it('should format list', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/listSecurityProblems.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          JSON.parse(readFileSync('src/capabilities/__tests__/resources/listSecurityProblems.json', 'utf8')),
+        ],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listSecurityProblems();
+      const response = await client.listSecurityProblems({}, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -128,10 +143,16 @@ describe('SecurityApiClient', () => {
         status: 'OPEN',
         title: `Security Problem ${i}`,
       }));
-      const response = {
-        totalCount: 123,
-        securityProblems: mockProblems,
-      };
+
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 123,
+            securityProblems: mockProblems,
+          },
+        ],
+      ]);
 
       const result = client.formatList(response);
 
@@ -142,12 +163,11 @@ describe('SecurityApiClient', () => {
     });
 
     it('should format list when sparse problem', async () => {
-      const mockResponse = {
-        securityProblems: [{}],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', { securityProblems: [{}] }]]);
 
-      const response = await client.listSecurityProblems();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listSecurityProblems({}, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -159,10 +179,10 @@ describe('SecurityApiClient', () => {
     });
 
     it('should format list when empty', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listSecurityProblems();
+      const response = await client.listSecurityProblems({}, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -170,10 +190,16 @@ describe('SecurityApiClient', () => {
     });
 
     it('should handle empty list', () => {
-      const response = {
-        totalCount: 0,
-        securityProblems: [],
-      };
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 0,
+            securityProblems: [],
+          },
+        ],
+      ]);
+
       const result = client.formatList(response);
       expect(result).toContain('Listing 0 security vulnerabilities');
     });
@@ -181,28 +207,31 @@ describe('SecurityApiClient', () => {
 
   describe('formatProblemDetails', () => {
     it('should format details', async () => {
-      const mockResponse = JSON.parse(
-        readFileSync('src/capabilities/__tests__/resources/getSecurityProblemDetails.json', 'utf8'),
-      );
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          JSON.parse(readFileSync('src/capabilities/__tests__/resources/getSecurityProblemDetails.json', 'utf8')),
+        ],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getSecurityProblemDetails('my-id');
+      const response = await client.getSecurityProblemDetails('my-id', 'testAlias');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of security problem in the following json');
+      expect(result).toContain('Details of security problem from environment testAlias in the following json');
       expect(result).toContain('"securityProblemId":"SP-123"');
     });
 
     it('should format details when sparse problem', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getSecurityProblemDetails('my-id');
+      const response = await client.getSecurityProblemDetails('my-id', 'testAlias');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of security problem in the following json');
+      expect(result).toContain('Details of security problem from environment testAlias in the following json');
       expect(result).toContain('{}');
     });
   });

--- a/src/capabilities/__tests__/slo-api.test.ts
+++ b/src/capabilities/__tests__/slo-api.test.ts
@@ -1,18 +1,21 @@
 import { SloApiClient, SLO } from '../slo-api';
-import { ManagedAuthClient } from '../../authentication/managed-auth-client';
+import { ManagedAuthClientManager } from '../../authentication/managed-auth-client';
 import { readFileSync } from 'fs';
 
 jest.mock('../../authentication/managed-auth-client');
 
 describe('SloApiClient', () => {
+  let mockAuthManager: jest.Mocked<ManagedAuthClientManager>;
   let client: SloApiClient;
-  let mockAuthClient: jest.Mocked<ManagedAuthClient>;
 
   beforeEach(() => {
-    mockAuthClient = {
-      makeRequest: jest.fn(),
+    mockAuthManager = {
+      makeRequests: jest.fn(),
+      getBaseUrl: jest.fn(() => {
+        return 'http://dashboardbaseurl.com/e/environment_id';
+      }),
     } as any;
-    client = new SloApiClient(mockAuthClient);
+    client = new SloApiClient(mockAuthManager);
   });
 
   afterEach(() => {
@@ -21,106 +24,131 @@ describe('SloApiClient', () => {
 
   describe('listSlos', () => {
     it('should list SLOs with default parameters', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.listSlos();
+      const result = await client.listSlos(undefined, 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo', {
-        pageSize: SloApiClient.API_PAGE_SIZE,
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/slo',
+        {
+          pageSize: SloApiClient.API_PAGE_SIZE,
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
 
     it('should list SLOs with all parameters', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.listSlos({
-        sloSelector: 'my-selector',
-        timeFrame: 'my-timeframe',
-        from: 'my-from',
-        to: 'my-to',
-        demo: true,
-        pageSize: 12,
-        evaluate: true,
-        sort: 'my-sort',
-        enabledSlos: 'my-enabled-slos',
-        showGlobalSlos: true,
-      });
+      const result = await client.listSlos(
+        {
+          sloSelector: 'my-selector',
+          timeFrame: 'my-timeframe',
+          from: 'my-from',
+          to: 'my-to',
+          demo: true,
+          pageSize: 12,
+          evaluate: true,
+          sort: 'my-sort',
+          enabledSlos: 'my-enabled-slos',
+          showGlobalSlos: true,
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo', {
-        sloSelector: 'my-selector',
-        timeFrame: 'my-timeframe',
-        from: 'my-from',
-        to: 'my-to',
-        demo: true,
-        pageSize: 12,
-        evaluate: true,
-        sort: 'my-sort',
-        enabledSlos: 'my-enabled-slos',
-        showGlobalSlos: true,
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/slo',
+        {
+          sloSelector: 'my-selector',
+          timeFrame: 'my-timeframe',
+          from: 'my-from',
+          to: 'my-to',
+          demo: true,
+          pageSize: 12,
+          evaluate: true,
+          sort: 'my-sort',
+          enabledSlos: 'my-enabled-slos',
+          showGlobalSlos: true,
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getSloDetails', () => {
     it('should get SLO details with defaults', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.getSloDetails({ id: 'slo-1' });
+      const result = await client.getSloDetails({ id: 'slo-1' }, 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo/slo-1', {});
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith('/api/v2/slo/slo-1', {}, 'testAlias');
       expect(result).toEqual(mockResponse);
     });
 
     it('should get SLO details with all parameters', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.getSloDetails({
-        id: 'slo-1',
-        from: 'now-12w',
-        to: 'now',
-        timeFrame: 'GTF',
-      });
+      const result = await client.getSloDetails(
+        {
+          id: 'slo-1',
+          from: 'now-12w',
+          to: 'now',
+          timeFrame: 'GTF',
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo/slo-1', {
-        from: 'now-12w',
-        to: 'now',
-        timeFrame: 'GTF',
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/slo/slo-1',
+        {
+          from: 'now-12w',
+          to: 'now',
+          timeFrame: 'GTF',
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
 
     it('should get SLO details with inferred timeFrame', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const result = await client.getSloDetails({
-        id: 'slo-1',
-        from: 'now-12w',
-        to: 'now',
-      });
+      const result = await client.getSloDetails(
+        {
+          id: 'slo-1',
+          from: 'now-12w',
+          to: 'now',
+        },
+        'testAlias',
+      );
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo/slo-1', {
-        from: 'now-12w',
-        to: 'now',
-        timeFrame: 'GTF',
-      });
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith(
+        '/api/v2/slo/slo-1',
+        {
+          from: 'now-12w',
+          to: 'now',
+          timeFrame: 'GTF',
+        },
+        'testAlias',
+      );
       expect(result).toEqual(mockResponse);
     });
 
     it('should handle URL encoding for SLO ID', async () => {
       const sloId = 'slo with spaces';
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      await client.getSloDetails({ id: sloId });
+      await client.getSloDetails({ id: sloId }, 'testAlias');
 
-      expect(mockAuthClient.makeRequest).toHaveBeenCalledWith('/api/v2/slo/slo%20with%20spaces', {});
+      expect(mockAuthManager.makeRequests).toHaveBeenCalledWith('/api/v2/slo/slo%20with%20spaces', {}, 'testAlias');
     });
   });
 
@@ -138,10 +166,16 @@ describe('SloApiClient', () => {
         errorBudget: 80,
         evaluatedPercentage: 96,
       }));
-      const response = {
-        totalCount: 123,
-        slo: mockSLOs,
-      };
+
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 123,
+            slo: mockSLOs,
+          },
+        ],
+      ]);
 
       const result = client.formatList(response);
 
@@ -152,10 +186,13 @@ describe('SloApiClient', () => {
     });
 
     it('should format list', async () => {
-      const mockResponse = JSON.parse(readFileSync('src/capabilities/__tests__/resources/listSlos.json', 'utf8'));
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/listSlos.json', 'utf8'))],
+      ]);
 
-      const response = await client.listSlos();
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
+
+      const response = await client.listSlos(undefined, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -166,12 +203,17 @@ describe('SloApiClient', () => {
     });
 
     it('should format list when sparse problem', async () => {
-      const mockResponse = {
-        slo: [{}],
-      };
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            slo: [{}],
+          },
+        ],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listSlos();
+      const response = await client.listSlos(undefined, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -182,10 +224,10 @@ describe('SloApiClient', () => {
     });
 
     it('should format list when empty', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.listSlos();
+      const response = await client.listSlos(undefined, 'testAlias');
       const result = client.formatList(response);
 
       expect(response).toEqual(mockResponse);
@@ -193,10 +235,16 @@ describe('SloApiClient', () => {
     });
 
     it('should handle empty list', () => {
-      const response = {
-        totalCount: 0,
-        slo: [],
-      };
+      const response = new Map<string, any>([
+        [
+          'testAlias',
+          {
+            totalCount: 0,
+            slo: [],
+          },
+        ],
+      ]);
+
       const result = client.formatList(response);
       expect(result).toContain('Listing 0 SLOs');
     });
@@ -204,26 +252,28 @@ describe('SloApiClient', () => {
 
   describe('formatDetails', () => {
     it('should format details', async () => {
-      const mockResponse = JSON.parse(readFileSync('src/capabilities/__tests__/resources/getSloDetails.json', 'utf8'));
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([
+        ['testAlias', JSON.parse(readFileSync('src/capabilities/__tests__/resources/getSloDetails.json', 'utf8'))],
+      ]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getSloDetails({ id: 'my-id' });
+      const response = await client.getSloDetails({ id: 'my-id' }, 'testAlias');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of SLO in the following json');
+      expect(result).toContain('Details of SLO from environment testAlias in the following json');
       expect(result).toContain('\"id\":\"0775c411-c3a1-3286-8fd2-8a469ae0a1b9\"');
     });
 
     it('should format details when sparse problem', async () => {
-      const mockResponse = {};
-      mockAuthClient.makeRequest.mockResolvedValue(mockResponse);
+      const mockResponse = new Map<string, any>([['testAlias', {}]]);
+      mockAuthManager.makeRequests.mockResolvedValue(mockResponse);
 
-      const response = await client.getSloDetails({ id: 'my-id' });
+      const response = await client.getSloDetails({ id: 'my-id' }, 'testAlias');
       const result = client.formatDetails(response);
 
       expect(response).toEqual(mockResponse);
-      expect(result).toContain('Details of SLO in the following json');
+      expect(result).toContain('Details of SLO from environment testAlias in the following json');
       expect(result).toContain('{}');
     });
   });

--- a/src/capabilities/events-api.ts
+++ b/src/capabilities/events-api.ts
@@ -1,4 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client.js';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client.js';
 
 import { formatTimestamp } from '../utils/date-formatter';
 import { logger } from '../utils/logger';
@@ -31,20 +31,14 @@ export interface Event {
   customProperties?: Record<string, any>;
 }
 
-export interface EventSearchResult {
-  events: Event[];
-  totalCount: number;
-  nextPageKey?: string;
-}
-
 export class EventsApiClient {
   static readonly API_PAGE_SIZE = 100;
   static readonly MAX_PROPERTIES_DISPLAY = 11;
   static readonly MAX_MANAGEMENT_ZONES_DISPLAY = 11;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async queryEvents(params: EventQueryParams): Promise<ListEventsResponse> {
+  async queryEvents(params: EventQueryParams, environment_aliases: string): Promise<Map<string, ListEventsResponse>> {
     const queryParams = {
       from: params.from,
       to: params.to,
@@ -53,98 +47,121 @@ export class EventsApiClient {
       ...(params.entitySelector && { entitySelector: params.entitySelector }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/events', queryParams);
-    logger.debug('queryEvents response: ', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/events', queryParams, environment_aliases);
+    logger.debug('queryEvents response: ', { data: responses });
+    return responses;
   }
 
-  async getEventDetails(eventId: string): Promise<any> {
-    const response = await this.authClient.makeRequest(`/api/v2/events/${encodeURIComponent(eventId)}`);
-    logger.debug('getEventDetails response: ', { data: response });
-    return response;
+  async getEventDetails(eventId: string, environment_aliases: string): Promise<Map<string, any>> {
+    const responses = await this.authManager.makeRequests(
+      `/api/v2/events/${encodeURIComponent(eventId)}`,
+      {},
+      environment_aliases,
+    );
+    logger.debug('getEventDetails response: ', { data: responses });
+    return responses;
   }
 
-  formatList(response: ListEventsResponse): string {
-    let totalCount = response.totalCount || -1;
-    let numEvents = response.events?.length || 0;
-    let isLimited = totalCount != 0 - 1 && totalCount > numEvents;
+  formatList(responses: Map<string, ListEventsResponse>): string {
+    let result = '';
+    let totalNumEvents = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
 
-    let result = 'Listing ' + numEvents + (totalCount == -1 ? '' : ' of ' + totalCount) + ' events.\n';
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let totalCount = data.totalCount || -1;
+      let numEvents = data.events?.length || 0;
+      totalNumEvents += numEvents;
+      let isLimited = totalCount != 0 - 1 && totalCount > numEvents;
 
-    if (isLimited) {
       result +=
-        'Not showing all matching problems. Consider using more specific filters (eventType, entitySelector) to get complete results.\n';
+        'Listing ' +
+        numEvents +
+        (totalCount == -1 ? '' : ' of ' + totalCount) +
+        ' events from environment ' +
+        alias +
+        '.\n\n';
+
+      if (isLimited) {
+        result +=
+          'Not showing all matching problems. Consider using more specific filters (eventType, entitySelector) to get complete results.\n';
+        anyLimited = true;
+      }
+
+      data.events?.forEach((event: any) => {
+        result += `eventId: ${event.eventId}\n`;
+        result += `  eventType: ${event.eventType}\n`;
+        result += `  status: ${event.status}\n`;
+        result += `  title: ${event.title}\n`;
+        if (event.description) {
+          result += `  ${event.description}\n`;
+        }
+        if (event.startTime && event.startTime !== -1) {
+          result += `. startTime: ${formatTimestamp(event.startTime)}`;
+        }
+        if (event.endTime && event.endTime !== -1) {
+          result += `. endTime: ${formatTimestamp(event.endTime)}`;
+        }
+        // High Priority: Add severity and impact levels
+        if (event.severityLevel) {
+          result += `severityLevel: ${event.severityLevel}\n`;
+        }
+        if (event.impactLevel) {
+          result += `impactLevel: ${event.impactLevel}\n`;
+        }
+        if (event.properties && Object.keys(event.properties).length > 0) {
+          const props = Object.entries(event.properties)
+            .slice(0, EventsApiClient.MAX_PROPERTIES_DISPLAY)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(', ');
+          result += `Properties: ${props}${Object.keys(event.properties).length > EventsApiClient.MAX_PROPERTIES_DISPLAY ? ` (+${Object.keys(event.properties).length - EventsApiClient.MAX_PROPERTIES_DISPLAY} more)` : ''}\n`;
+        }
+        if (event.managementZones && event.managementZones.length > 0) {
+          const zones = event.managementZones
+            .slice(0, EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY)
+            .map((zone: any) => zone.name || zone.id || zone)
+            .join(', ');
+          result += `Management Zones: ${zones}${event.managementZones.length > EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY ? ` (+${event.managementZones.length - EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY} more)` : ''}\n`;
+        }
+
+        result += '\n';
+      });
     }
-
-    response.events?.forEach((event: any) => {
-      result += `eventId: ${event.eventId}\n`;
-      result += `  eventType: ${event.eventType}\n`;
-      result += `  status: ${event.status}\n`;
-      result += `  title: ${event.title}\n`;
-      if (event.description) {
-        result += `  ${event.description}\n`;
-      }
-      if (event.startTime && event.startTime !== -1) {
-        result += `. startTime: ${formatTimestamp(event.startTime)}`;
-      }
-      if (event.endTime && event.endTime !== -1) {
-        result += `. endTime: ${formatTimestamp(event.endTime)}`;
-      }
-      // High Priority: Add severity and impact levels
-      if (event.severityLevel) {
-        result += `severityLevel: ${event.severityLevel}\n`;
-      }
-      if (event.impactLevel) {
-        result += `impactLevel: ${event.impactLevel}\n`;
-      }
-      if (event.properties && Object.keys(event.properties).length > 0) {
-        const props = Object.entries(event.properties)
-          .slice(0, EventsApiClient.MAX_PROPERTIES_DISPLAY)
-          .map(([k, v]) => `${k}=${v}`)
-          .join(', ');
-        result += `Properties: ${props}${Object.keys(event.properties).length > EventsApiClient.MAX_PROPERTIES_DISPLAY ? ` (+${Object.keys(event.properties).length - EventsApiClient.MAX_PROPERTIES_DISPLAY} more)` : ''}\n`;
-      }
-      if (event.managementZones && event.managementZones.length > 0) {
-        const zones = event.managementZones
-          .slice(0, EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY)
-          .map((zone: any) => zone.name || zone.id || zone)
-          .join(', ');
-        result += `Management Zones: ${zones}${event.managementZones.length > EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY ? ` (+${event.managementZones.length - EventsApiClient.MAX_MANAGEMENT_ZONES_DISPLAY} more)` : ''}\n`;
-      }
-
-      result += '\n';
-    });
-
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
     result +=
       '\n' +
       'Next Steps:\n' +
-      (numEvents == 0
+      (totalNumEvents == 0
         ? '* Try broader search terms or expand the time range; if using an entitySelector, check with discover_entities which entities that matches.\n'
         : '') +
-      (isLimited
+      (anyLimited
         ? '* Use more restrictive filters, such as a narrower time range or more specific search terms.\n'
         : '') +
-      (numEvents > 0
+      (totalNumEvents > 0
         ? '* If the user is interested in a specific event, use the get_event_details tool. Use the event id for this.\n '
         : '') +
-      '* Suggest to the user that they use the Dynatrace UI to view events at ' +
-      `${this.authClient.dashboardBaseUrl}/ by navigating to the relevant entity\n` +
+      '* Suggest to the user that they use the Dynatrace UI' +
+      (baseUrl ? ` at ${baseUrl} ` : ' ') +
+      +'to view events by navigating to the relevant entity\n' +
       '* Use list_problems to see what problems Dynatrace knows of, if not already done so.\n';
 
     return result;
   }
 
-  formatDetails(response: any): string {
-    let result =
-      `Event details in the following json:\n` +
-      JSON.stringify(response) +
-      '\n' +
+  formatDetails(responses: Map<string, any>): string {
+    let result = '';
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      result += 'Event details from environment ' + alias + ' in the following json:\n' + JSON.stringify(data) + '\n';
+    }
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
+    result +=
       'Next Steps:\n' +
-      '* Suggest to the user that they explore this further in the Dynatrace UI at ' +
-      `${this.authClient.dashboardBaseUrl}/` +
-      '\n' +
-      '* Use list_problems to see what problems Dynatrace knows of, if not already done so.\n';
-
+      '* Suggest to the user that they explore this further in the Dynatrace UI' +
+      (baseUrl ? ` at ${baseUrl} ` : '.') +
+      '\n* Use list_problems to see what problems Dynatrace knows of, if not already done so.\n';
     return result;
   }
 }

--- a/src/capabilities/logs-api.ts
+++ b/src/capabilities/logs-api.ts
@@ -1,4 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client.js';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client.js';
 import { formatTimestamp } from '../utils/date-formatter';
 import { logger } from '../utils/logger';
 
@@ -28,19 +28,12 @@ export interface LogEntry {
   [key: string]: any;
 }
 
-export interface LogSearchResult {
-  results: LogEntry[];
-  totalCount: number;
-  nextPageKey?: string;
-  sliceSize?: number;
-}
-
 export class LogsApiClient {
   private static readonly API_PAGE_SIZE = 1000;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async queryLogs(params: LogQueryParams): Promise<ListLogsResponse> {
+  async queryLogs(params: LogQueryParams, environment_aliases: string): Promise<Map<string, ListLogsResponse>> {
     const queryParams = {
       query: params.query || '',
       from: params.from,
@@ -49,62 +42,74 @@ export class LogsApiClient {
       sort: params.sort || '-timestamp',
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/logs/search', queryParams);
-    logger.debug('queryLogs response', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/logs/search', queryParams, environment_aliases);
+    logger.debug('queryLogs response: ', { data: responses });
+    return responses;
   }
 
-  formatList(response: ListLogsResponse): string {
-    let numLogs = response.results?.length || 0;
-    let isLimited = response.nextSliceKey != undefined;
+  formatList(responses: Map<string, ListLogsResponse>): string {
+    let result = '';
+    let totalNumLogs = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let numLogs = data.results?.length || 0;
+      totalNumLogs = totalNumLogs + numLogs;
+      let isLimited = data.nextSliceKey != undefined;
 
-    let result = 'Listing ' + numLogs + ' log records.\n';
+      result += 'Listing ' + numLogs + ' log records from environment ' + alias + '.\n\n';
 
-    if (isLimited) {
-      result += 'Results likely restricted due to maximum response size, consider using a more specific filter.';
+      if (isLimited) {
+        result += 'Results likely restricted due to maximum response size, consider using a more specific filter.';
+        anyLimited = true;
+      }
+
+      data.results?.forEach((log: any) => {
+        const timestamp = formatTimestamp(log.timestamp);
+        // Enhanced level detection for better error identification
+        let level = log.additionalColumns?.loglevel?.[0] || log.status || log.log_level || 'NONE';
+
+        result += `**${timestamp}** [${level}]\n`;
+        result += `${log.content}\n`;
+
+        // Medium Priority: Show eventType if available
+        if (log.eventType) {
+          result += `Event Type: ${log.eventType}\n`;
+        }
+
+        const metadata: string[] = [];
+        if (log.additionalColumns) {
+          Object.entries(log.additionalColumns).forEach(([key, value]) => {
+            if (Array.isArray(value) && value.length > 0) {
+              metadata.push(`${key}: ${value[0]}`);
+            }
+          });
+        }
+        if (metadata.length > 0) {
+          // Medium Priority: Increased from 5 to 8 metadata fields
+          result += `_${metadata.slice(0, 8).join(', ')}_\n`;
+          if (metadata.length > 8) {
+            result += `_... and ${metadata.length - 8} more metadata fields_\n`;
+          }
+        }
+        result += '\n\n';
+      });
     }
 
-    response.results?.forEach((log: any) => {
-      const timestamp = formatTimestamp(log.timestamp);
-      // Enhanced level detection for better error identification
-      let level = log.additionalColumns?.loglevel?.[0] || log.status || log.log_level || 'NONE';
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
 
-      result += `**${timestamp}** [${level}]\n`;
-      result += `${log.content}\n`;
-
-      // Medium Priority: Show eventType if available
-      if (log.eventType) {
-        result += `Event Type: ${log.eventType}\n`;
-      }
-
-      const metadata: string[] = [];
-      if (log.additionalColumns) {
-        Object.entries(log.additionalColumns).forEach(([key, value]) => {
-          if (Array.isArray(value) && value.length > 0) {
-            metadata.push(`${key}: ${value[0]}`);
-          }
-        });
-      }
-      if (metadata.length > 0) {
-        // Medium Priority: Increased from 5 to 8 metadata fields
-        result += `_${metadata.slice(0, 8).join(', ')}_\n`;
-        if (metadata.length > 8) {
-          result += `_... and ${metadata.length - 8} more metadata fields_\n`;
-        }
-      }
-      result += '\n';
-    });
-
-    result +=
+    result =
+      result +
       '\n' +
       'Next Steps:\n' +
-      (numLogs == 0 ? '* Try broader search terms or expand the time range\n' : '') +
-      (isLimited
+      (totalNumLogs == 0 ? '* Try broader search terms or expand the time range\n' : '') +
+      (anyLimited
         ? '* Use more restrictive filters, such as a narrower time range or more specific search terms\n'
         : '') +
-      (numLogs > 1 ? '* Use sort (e.g. with "-timestamp" for newest logs first).\n' : '') +
-      '* Suggest to the user that they use the Dynatrace UI to view metric data at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/log-monitoring` +
+      (totalNumLogs > 1 ? '* Use sort (e.g. with "-timestamp" for newest logs first).\n' : '') +
+      '* Suggest to the user that they use the Dynatrace UI to view metric data' +
+      (baseUrl ? ` at ${baseUrl}/ui/log-monitoring.` : '.') +
       '\n' +
       '* Use list_problems to see what problems Dynatrace knows of, if not already done so\n';
 

--- a/src/capabilities/metrics-api.ts
+++ b/src/capabilities/metrics-api.ts
@@ -1,5 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client.js';
-import { formatTimestamp } from '../utils/date-formatter';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client.js';
 import { logger } from '../utils/logger';
 
 export interface MetricListParams {
@@ -63,9 +62,12 @@ export class MetricsApiClient {
   static readonly API_PAGE_SIZE = 500;
   static readonly MAX_DIMENSIONS_DISPLAY = 11;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async listAvailableMetrics(params: MetricListParams = {}): Promise<ListMetricsResponse> {
+  async listAvailableMetrics(
+    params: MetricListParams = {},
+    environment_aliases: string,
+  ): Promise<Map<string, ListMetricsResponse>> {
     const queryParams = {
       pageSize: params.pageSize || MetricsApiClient.API_PAGE_SIZE,
       ...(params.entitySelector && { entitySelector: params.entitySelector }),
@@ -76,18 +78,24 @@ export class MetricsApiClient {
       ...(params.nextPageKey && { nextPageKey: params.nextPageKey }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/metrics', queryParams);
-    logger.debug('listAvailableMetrics response', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/metrics', queryParams, environment_aliases);
+    logger.debug(`listAvailableMetrics responses from ${this.authManager.clients?.length} sources: `, {
+      data: responses,
+    });
+    return responses;
   }
 
-  async getMetricDetails(metricId: string): Promise<any> {
-    const response = await this.authClient.makeRequest(`/api/v2/metrics/${encodeURIComponent(metricId)}`);
-    logger.debug(`getMetricDetails response, metricId=${metricId}`, { data: response });
-    return response;
+  async getMetricDetails(metricId: string, environment_aliases: string): Promise<Map<string, any>> {
+    const responses = await this.authManager.makeRequests(
+      `/api/v2/metrics/${encodeURIComponent(metricId)}`,
+      {},
+      environment_aliases,
+    );
+    logger.debug(`getMetricDetails response, metricId=${metricId}`, { data: responses });
+    return responses;
   }
 
-  async queryMetrics(params: MetricQueryParams): Promise<MetricDataResponse> {
+  async queryMetrics(params: MetricQueryParams, environment_aliases: string): Promise<Map<string, MetricDataResponse>> {
     const queryParams = {
       metricSelector: params.metricSelector,
       resolution: params.resolution || 'Inf',
@@ -96,132 +104,160 @@ export class MetricsApiClient {
       ...(params.entitySelector && { entitySelector: params.entitySelector }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/metrics/query', queryParams);
-    logger.debug(`queryMetrics response, params=${JSON.stringify(params)}`, { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/metrics/query', queryParams, environment_aliases);
+    logger.debug(`queryMetrics response, params=${JSON.stringify(params)}`, { data: responses });
+    return responses;
   }
 
-  formatMetricList(response: ListMetricsResponse): string {
-    let totalCount = response?.totalCount || -1;
-    let numMetrics = response?.metrics?.length || 0;
-    let isLimited = totalCount != 0 - 1 && totalCount > numMetrics;
+  formatMetricList(responses: Map<string, ListMetricsResponse>): string {
+    let result = '';
+    let totalNumMetrics = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let totalCount = data.totalCount || -1;
+      let numMetrics = data.metrics?.length || 0;
+      totalNumMetrics += numMetrics;
+      let isLimited = totalCount != 0 - 1 && totalCount > numMetrics;
 
-    let result = 'Listing ' + numMetrics + (totalCount == -1 ? '' : ' of ' + totalCount) + ' metrics.\n';
+      result +=
+        'Listing ' +
+        numMetrics +
+        (totalCount == -1 ? '' : ' of ' + totalCount) +
+        ' metrics from environment ' +
+        alias +
+        '.\n\n';
 
-    if (isLimited) {
-      result += 'Not showing all matching metrics. Consider using more specific filters to get complete results.\n';
-    }
-
-    response.metrics?.forEach((metric: any) => {
-      result += `metricId: ${metric.metricId}\n`;
-      if (metric.displayName) result += `  displayName: ${metric.displayName}\n`;
-      if (metric.description) result += `  description: ${metric.description}\n`;
-      if (metric.unit) result += `  unit: ${metric.unit}\n`;
-
-      // High Priority: Add aggregation types
-      if (metric.aggregationTypes && metric.aggregationTypes.length > 0) {
-        result += `  aggregationTypes: ${metric.aggregationTypes.join(', ')}\n`;
+      if (isLimited) {
+        result += 'Not showing all matching metrics. Consider using more specific filters to get complete results.\n';
+        anyLimited = true;
       }
 
-      // High Priority: Add dimension definitions (key for filtering)
-      if (metric.dimensionDefinitions && metric.dimensionDefinitions.length > 0) {
-        const dims = metric.dimensionDefinitions
-          .slice(0, MetricsApiClient.MAX_DIMENSIONS_DISPLAY)
-          .map((dim: any) => dim.name)
-          .join(', ');
-        result += `  dimensions: ${dims}${metric.dimensionDefinitions.length > MetricsApiClient.MAX_DIMENSIONS_DISPLAY ? ` (+${metric.dimensionDefinitions.length - MetricsApiClient.MAX_DIMENSIONS_DISPLAY} more)` : ''}\n`;
-      }
+      data.metrics?.forEach((metric: any) => {
+        result += `metricId: ${metric.metricId}\n`;
+        if (metric.displayName) result += `  displayName: ${metric.displayName}\n`;
+        if (metric.description) result += `  description: ${metric.description}\n`;
+        if (metric.unit) result += `  unit: ${metric.unit}\n`;
 
-      result += '\n';
-    });
-
-    result +=
-      '\n' +
-      'Next Steps:\n' +
-      (numMetrics == 0 ? '* Verify that the filters were correct, and search again with different filters\n' : '') +
-      (isLimited
-        ? '* To filter the list of metrics, use list_available_metrics tool with sorting and with specific filters (e.g. entitySelector and searchText).\n'
-        : '') +
-      '* Use get_metric_details tool for detailed information of a particular metric.\n' +
-      '* Suggest to the user that they use the Dynatrace UI to:\n' +
-      `   * Browse the list of metrics at ${this.authClient.dashboardBaseUrl}/ui/metrics' + '\n` +
-      `   * View metric data at ${this.authClient.dashboardBaseUrl}/ui/data-explorer' + '\n`;
-
-    return result;
-  }
-
-  formatMetricDetails(response: any): string {
-    let result =
-      'Details of metric in the following json.\n' +
-      JSON.stringify(response) +
-      '\n' +
-      'Next Steps:\n' +
-      '* Suggest to the user that they use the Dynatrace UI to view metric data at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/data-explorer`;
-
-    return result;
-  }
-
-  formatMetricData(response: MetricDataResponse): string {
-    let resolution = response.resolution;
-    let isNonEmpty =
-      response.result && response.result.length > 0 && response.result[0].data && response.result[0].data.length > 0;
-
-    let result = 'Listing data series';
-
-    if (!isNonEmpty) {
-      result += ' (no datapoints found)\n';
-    } else {
-      result += ', each with timestamped datapoints of the form timestamp: value, timestamp: value, ...\n';
-    }
-
-    if (resolution) {
-      result += `resolution: ${resolution}\n`;
-    }
-
-    response.result?.forEach((metric: any) => {
-      let numDataseries = metric.data?.length || 0;
-
-      result += 'Listing ' + numDataseries + ' data series\n';
-      result += `metricId: ${metric.metricId}\n`;
-
-      metric.data?.forEach((series: any) => {
-        let timestamps = series.timestamps || [];
-        let values = series.values || [];
-
-        if (series.dimensionMap) {
-          result += `  dimensionData: ${JSON.stringify(series.dimensionMap)}\n`;
+        // High Priority: Add aggregation types
+        if (metric.aggregationTypes && metric.aggregationTypes.length > 0) {
+          result += `  aggregationTypes: ${metric.aggregationTypes.join(', ')}\n`;
         }
-        if (series.dimensions) {
-          result += `  dimensions: ${JSON.stringify(series.dimensions)}\n`;
-        }
-        if (timestamps.length > 0) {
-          let formattedDatapoints = '';
-          let numDatapoints = Math.min(timestamps.length, values.length);
-          for (let i = 0; i < Math.min(numDatapoints, MetricsApiClient.MAX_DATA_POINTS); i++) {
-            formattedDatapoints += `${timestamps[i]}: ${values[i]}, `;
-          }
-          result += `  timestamped datapoints: ${formattedDatapoints}`;
-          if (numDatapoints > MetricsApiClient.MAX_DATA_POINTS) {
-            result += ` and ${numDatapoints - MetricsApiClient.MAX_DATA_POINTS} more data points`;
-          }
-          result += '\n';
-        } else {
-          result += `  No datapoints\n`;
+
+        // High Priority: Add dimension definitions (key for filtering)
+        if (metric.dimensionDefinitions && metric.dimensionDefinitions.length > 0) {
+          const dims = metric.dimensionDefinitions
+            .slice(0, MetricsApiClient.MAX_DIMENSIONS_DISPLAY)
+            .map((dim: any) => dim.name)
+            .join(', ');
+          result += `  dimensions: ${dims}${metric.dimensionDefinitions.length > MetricsApiClient.MAX_DIMENSIONS_DISPLAY ? ` (+${metric.dimensionDefinitions.length - MetricsApiClient.MAX_DIMENSIONS_DISPLAY} more)` : ''}\n`;
         }
         result += '\n';
       });
-    });
+    }
+
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
 
     result +=
       '\n' +
       'Next Steps:\n' +
-      (!isNonEmpty
+      (totalNumMetrics == 0
+        ? '* Verify that the filters were correct, and search again with different filters\n'
+        : '') +
+      (anyLimited
+        ? '* To filter the list of metrics, use list_available_metrics tool with sorting and with specific filters (e.g. entitySelector and searchText).\n'
+        : '') +
+      '* Use get_metric_details tool for detailed information of a particular metric.\n' +
+      '* Suggest to the user that they use the Dynatrace UI' +
+      (baseUrl
+        ? ` to: \n * Browse the list of metrics at ${baseUrl}/ui/metrics` +
+          `\n * View metric data at ${baseUrl}/ui/data-explorer`
+        : '.');
+
+    return result;
+  }
+
+  formatMetricDetails(responses: Map<string, any>): string {
+    let result = '';
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      result +=
+        'Details of metric from environment ' + alias + ' in the following json:\n' + JSON.stringify(data) + '\n';
+    }
+
+    result += 'Next Steps:\n* Suggest to the user that they use the Dynatrace UI to view metric data';
+    return result;
+  }
+
+  formatMetricData(responses: Map<string, MetricDataResponse>): string {
+    let result = '';
+    let allEmpty = true;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let resolution = data.resolution;
+      let isNonEmpty = data.result && data.result.length > 0 && data.result[0].data && data.result[0].data.length > 0;
+
+      result += 'Listing data series from environment ' + alias;
+
+      if (!isNonEmpty) {
+        result += ' (no datapoints found)\n';
+      } else {
+        result += ', each with timestamped datapoints of the form timestamp: value, timestamp: value, ...\n';
+        allEmpty = false;
+      }
+
+      if (resolution) {
+        result += `resolution: ${resolution}\n`;
+      }
+
+      data.result?.forEach((metric: any) => {
+        let numDataseries = metric.data?.length || 0;
+
+        result += 'Listing ' + numDataseries + ' data series\n';
+        result += `metricId: ${metric.metricId}\n`;
+
+        metric.data?.forEach((series: any) => {
+          let timestamps = series.timestamps || [];
+          let values = series.values || [];
+
+          if (series.dimensionMap) {
+            result += `  dimensionData: ${JSON.stringify(series.dimensionMap)}\n`;
+          }
+          if (series.dimensions) {
+            result += `  dimensions: ${JSON.stringify(series.dimensions)}\n`;
+          }
+          if (timestamps.length > 0) {
+            let formattedDatapoints = '';
+            let numDatapoints = Math.min(timestamps.length, values.length);
+            for (let i = 0; i < Math.min(numDatapoints, MetricsApiClient.MAX_DATA_POINTS); i++) {
+              formattedDatapoints += `${timestamps[i]}: ${values[i]}, `;
+            }
+            result += `  timestamped datapoints: ${formattedDatapoints}`;
+            if (numDatapoints > MetricsApiClient.MAX_DATA_POINTS) {
+              result += ` and ${numDatapoints - MetricsApiClient.MAX_DATA_POINTS} more data points`;
+            }
+            result += '\n';
+          } else {
+            result += `  No datapoints\n`;
+          }
+          result += '\n\n';
+        });
+      });
+    }
+
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
+
+    result +=
+      '\n' +
+      'Next Steps:\n' +
+      (allEmpty
         ? '* Verify that the filters were correct, and search again with different filters\n'
         : '* Use query_metrics_data with more specific filters, such as a narrower time range with to and from, and an entitySelector\n') +
-      '* Suggest to the user that they use the Dynatrace UI to view metric data at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/data-explorer` +
-      '\n';
+      '* Suggest to the user that they use the Dynatrace UI to view metric data' +
+      (baseUrl ? ` at ${baseUrl}/ui/data-explorer` : '.');
 
     return result;
   }

--- a/src/capabilities/problems-api.ts
+++ b/src/capabilities/problems-api.ts
@@ -1,4 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client.js';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client.js';
 import { formatTimestamp } from '../utils/date-formatter';
 import { logger } from '../utils/logger';
 
@@ -71,9 +71,12 @@ export interface Evidence {
 export class ProblemsApiClient {
   static readonly API_PAGE_SIZE = 50;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async listProblems(params: ProblemQueryParams = {}): Promise<ListProblemResponse> {
+  async listProblems(
+    params: ProblemQueryParams = {},
+    environment_aliases: string,
+  ): Promise<Map<string, ListProblemResponse>> {
     const queryParams = {
       pageSize: params.pageSize || ProblemsApiClient.API_PAGE_SIZE,
       ...(params.from && { from: params.from }),
@@ -84,77 +87,103 @@ export class ProblemsApiClient {
       ...(params.sort && { sort: params.sort }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/problems', queryParams);
+    const responses = await this.authManager.makeRequests('/api/v2/problems', queryParams, environment_aliases);
 
-    logger.debug('listProblems response', { data: response });
-    return response;
+    logger.debug('listProblems response', { data: responses });
+    return responses;
   }
 
-  async getProblemDetails(problemId: string): Promise<any> {
-    const response = await this.authClient.makeRequest(`/api/v2/problems/${encodeURIComponent(problemId)}`);
+  async getProblemDetails(problemId: string, environment_aliases: string): Promise<Map<string, any>> {
+    const responses = await this.authManager.makeRequests(
+      `/api/v2/problems/${encodeURIComponent(problemId)}`,
+      {},
+      environment_aliases,
+    );
 
-    logger.debug('getProblemDetails response', { data: response });
-    return response;
+    logger.debug('getProblemDetails response', { data: responses });
+    return responses;
   }
 
-  formatList(response: ListProblemResponse): string {
-    let totalCount = response.totalCount || -1;
-    let numProblems = response.problems?.length || 0;
-    let isLimited = totalCount != 0 - 1 && totalCount > numProblems;
+  formatList(responses: Map<string, ListProblemResponse>): string {
+    let result = '';
+    let totalNumProblems = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let totalCount = data.totalCount || -1;
+      let numProblems = data.problems?.length || 0;
+      totalNumProblems += numProblems;
+      let isLimited = totalCount != 0 - 1 && totalCount > numProblems;
 
-    let result = 'Listing ' + numProblems + (totalCount == -1 ? '' : ' of ' + totalCount) + ' problems.\n';
-
-    if (isLimited) {
       result +=
-        'Not showing all matching problems. Consider using more specific filters (status, impactLevel, entitySelector) to get complete results.\n';
-    }
+        'Listing ' +
+        numProblems +
+        (totalCount == -1 ? '' : ' of ' + totalCount) +
+        ' problems from environment ' +
+        alias +
+        '.\n\n';
 
-    response.problems?.forEach((problem: any) => {
-      result += `problemId: ${problem.problemId}\n`;
-      result += `  displayId: ${problem.displayId}\n`;
-      result += `  title: ${problem.title}\n`;
-      result += `  status: ${problem.status}\n`;
-      result += `  severityLevel: ${problem.severityLevel}\n`;
-      result += `  impactLevel: ${problem.impactLevel}\n`;
-      result += `  severityLevel: ${problem.severityLevel}\n`;
-      if (problem.startTime) {
-        result += `  startTime: ${formatTimestamp(problem.startTime)}\n`;
+      if (isLimited) {
+        result +=
+          'Not showing all matching problems. Consider using more specific filters (status, impactLevel, entitySelector) to get complete results.\n';
+        anyLimited = true;
       }
-      if (problem.endTime && problem.endTime != -1) {
-        result += `  endTime: ${formatTimestamp(problem.endTime)}\n`;
-      }
-      result += '\n';
-    });
+
+      data.problems?.forEach((problem: any) => {
+        result += `problemId: ${problem.problemId}\n`;
+        result += `  displayId: ${problem.displayId}\n`;
+        result += `  title: ${problem.title}\n`;
+        result += `  status: ${problem.status}\n`;
+        result += `  severityLevel: ${problem.severityLevel}\n`;
+        result += `  impactLevel: ${problem.impactLevel}\n`;
+        result += `  severityLevel: ${problem.severityLevel}\n`;
+        if (problem.startTime) {
+          result += `  startTime: ${formatTimestamp(problem.startTime)}\n`;
+        }
+        if (problem.endTime && problem.endTime != -1) {
+          result += `  endTime: ${formatTimestamp(problem.endTime)}\n`;
+        }
+        result += '\n';
+      });
+    }
 
     result +=
       '\n' +
       'Next Steps:\n' +
-      (numProblems == 0
+      (totalNumProblems == 0
         ? '* Verify that the filters such as entitySelector and time range were correct, and search again with different filters.\n'
         : '') +
-      (isLimited ? '* Use more restrictive filters, such as a more specific entitySelector.\n' : '') +
-      (numProblems > 1 ? '* Use sort (e.g. with "+status" for open problems first).\n' : '') +
-      '* Suggest to the user that they view the problems in the Dynatrace UI at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/problems` +
-      '\n' +
-      '* If the user is interested in a specific problem, use the get_problem_details tool. ' +
+      (anyLimited ? '* Use more restrictive filters, such as a more specific entitySelector.\n' : '') +
+      (totalNumProblems > 1 ? '* Use sort (e.g. with "+status" for open problems first).\n' : '') +
+      '* Suggest to the user that they view the problems in the Dynatrace UI';
+
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
+
+    result +=
+      (baseUrl ? ` at ${baseUrl}/ui/problems.` : '.') +
+      '\n* If the user is interested in a specific problem, use the get_problem_details tool. ' +
       'Use the problemId (UUID) for detailed analysis.\n';
 
     return result;
   }
 
-  formatDetails(response: any): string {
-    let result =
-      'Details of problem in the following json.\n' +
-      JSON.stringify(response) +
-      '\n' +
+  formatDetails(responses: Map<string, any>): string {
+    let result = '';
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      result +=
+        'Details of problem from environment ' + alias + ' in the following json:\n' + JSON.stringify(data) + '\n';
+    }
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
+    result +=
       'Next Steps:\n' +
-      '* If the affectedEntities is not empty, suggest to the user that they could investigate those entities further. For example with:\n';
-    ("   * list_events tool, using the affected entity's entityId in the entitySelector.\n");
-    ('   * query_logs tool, for a narrow time range of the problem, searching for logs about that entity.\n');
-    '* Suggest to the user that they view the problem in the Dynatrace UI ' +
-      `${this.authClient.dashboardBaseUrl}/#problems/problemdetails;pid=<problemId>, using the problemId in the URL` +
-      '\n';
+      '* If the affectedEntities is not empty, suggest to the user that they could investigate those entities further. For example with:\n' +
+      "   * list_events tool, using the affected entity's entityId in the entitySelector.\n" +
+      '   * query_logs tool, for a narrow time range of the problem, searching for logs about that entity.\n' +
+      '   * Suggest to the user that they view the problem in the Dynatrace UI' +
+      (baseUrl ? ` at ${baseUrl}/#problems/problemdetails;pid=<problemId>, using the problemId in the URL` : '.');
 
     return result;
   }

--- a/src/capabilities/security-api.ts
+++ b/src/capabilities/security-api.ts
@@ -1,4 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client';
 
 import { formatTimestamp } from '../utils/date-formatter';
 import { logger } from '../utils/logger';
@@ -59,29 +59,16 @@ export interface SecurityProblem {
   lastUpdatedTimestamp?: number;
 }
 
-export interface SecurityProblemDetail extends SecurityProblem {
-  description?: string;
-  remediationItems?: Array<{
-    id: string;
-    name: string;
-    type: string;
-    state: string;
-  }>;
-  events?: Array<{
-    eventType: string;
-    timestamp: number;
-    entityId?: string;
-  }>;
-  codeLocations?: any[];
-}
-
 export class SecurityApiClient {
   static readonly API_PAGE_SIZE = 200;
   static readonly MAX_CVES_DISPLAY = 11;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async listSecurityProblems(params: SecurityProblemQueryParams = {}): Promise<ListSecurityProblemsResponse> {
+  async listSecurityProblems(
+    params: SecurityProblemQueryParams = {},
+    environment_aliases: string,
+  ): Promise<Map<string, ListSecurityProblemsResponse>> {
     const queryParams = {
       pageSize: params.pageSize || SecurityApiClient.API_PAGE_SIZE,
       ...(params.riskLevel && { riskLevel: params.riskLevel }),
@@ -92,83 +79,115 @@ export class SecurityApiClient {
       ...(params.sort && { sort: params.sort }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/securityProblems', queryParams);
-    logger.debug('listSecurityProblems response', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/securityProblems', queryParams, environment_aliases);
+    logger.debug('listSecurityProblems response', { data: responses });
+    return responses;
   }
 
-  async getSecurityProblemDetails(problemId: string): Promise<any> {
-    const response = await this.authClient.makeRequest(`/api/v2/securityProblems/${encodeURIComponent(problemId)}`);
-    logger.debug('getSecurityProblemDetails response', { data: response });
-    return response;
+  async getSecurityProblemDetails(problemId: string, environment_aliases: string): Promise<Map<string, any>> {
+    const responses = await this.authManager.makeRequests(
+      `/api/v2/securityProblems/${encodeURIComponent(problemId)}`,
+      {},
+      environment_aliases,
+    );
+    logger.debug('getSecurityProblemDetails response', { data: responses });
+    return responses;
   }
 
-  formatList(response: ListSecurityProblemsResponse): string {
-    let totalCount = response.totalCount || -1;
-    let numProblems = response.securityProblems?.length || 0;
-    let isLimited = totalCount != 0 - 1 && totalCount > numProblems;
+  formatList(responses: Map<string, ListSecurityProblemsResponse>): string {
+    let result = '';
+    let totalNumProblems = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let totalCount = data.totalCount || -1;
+      let numProblems = data.securityProblems?.length || 0;
+      totalNumProblems += numProblems;
+      let isLimited = totalCount != 0 - 1 && totalCount > numProblems;
 
-    let result =
-      'Listing ' +
-      numProblems +
-      (totalCount == -1 ? '' : ' of ' + totalCount) +
-      ' security vulnerabilities in the following json.\n';
-
-    if (isLimited) {
       result +=
-        'Not showing all matching vulnerabilities. Consider using more specific filters (status, impactLevel, entitySelector) to get complete results.\n';
+        'Listing ' +
+        numProblems +
+        (totalCount == -1 ? '' : ' of ' + totalCount) +
+        ' security vulnerabilities from environment ' +
+        alias +
+        ' in the following json.\n';
+
+      if (isLimited) {
+        result +=
+          'Not showing all matching vulnerabilities. Consider using more specific filters (status, impactLevel, entitySelector) to get complete results.\n';
+        anyLimited = true;
+      }
+
+      data.securityProblems?.forEach((problem: any) => {
+        result += `securityProblemId: ${problem.securityProblemId}\n`;
+        result += `  displayId: ${problem.displayId}\n`;
+        result += `  title: ${problem.title}\n`;
+        result += `  status: ${problem.status}\n`;
+        result += `  vulnerabilityType: ${problem.vulnerabilityType}\n`;
+        result += `  technology: ${problem.technology}\n`;
+        if (problem.riskAssessment) {
+          result +=
+            `  riskLevel: ${problem.riskAssessment.riskLevel}; ` +
+            `riskScore: ${problem.riskAssessment.riskScore}; ` +
+            `exposure: ${problem.riskAssessment.exposure}\n`;
+        }
+        if (problem.cveIds && problem.cveIds.length > 0) {
+          result +=
+            `  cveIds: ${problem.cveIds.slice(0, SecurityApiClient.MAX_CVES_DISPLAY).join(', ')}` +
+            `${problem.cveIds.length > SecurityApiClient.MAX_CVES_DISPLAY ? ` (+${problem.cveIds.length - SecurityApiClient.MAX_CVES_DISPLAY} more)` : ''}\n`;
+        }
+        if (problem.firstSeenTimestamp) {
+          result += `  firstSeen: ${formatTimestamp(problem.firstSeenTimestamp)}\n`;
+        }
+        result += '\n';
+      });
     }
 
-    response.securityProblems?.forEach((problem: any) => {
-      result += `securityProblemId: ${problem.securityProblemId}\n`;
-      result += `  displayId: ${problem.displayId}\n`;
-      result += `  title: ${problem.title}\n`;
-      result += `  status: ${problem.status}\n`;
-      result += `  vulnerabilityType: ${problem.vulnerabilityType}\n`;
-      result += `  technology: ${problem.technology}\n`;
-      if (problem.riskAssessment) {
-        result +=
-          `  riskLevel: ${problem.riskAssessment.riskLevel}; ` +
-          `riskScore: ${problem.riskAssessment.riskScore}; ` +
-          `exposure: ${problem.riskAssessment.exposure}\n`;
-      }
-      if (problem.cveIds && problem.cveIds.length > 0) {
-        result +=
-          `  cveIds: ${problem.cveIds.slice(0, SecurityApiClient.MAX_CVES_DISPLAY).join(', ')}` +
-          `${problem.cveIds.length > SecurityApiClient.MAX_CVES_DISPLAY ? ` (+${problem.cveIds.length - SecurityApiClient.MAX_CVES_DISPLAY} more)` : ''}\n`;
-      }
-      if (problem.firstSeenTimestamp) {
-        result += `  firstSeen: ${formatTimestamp(problem.firstSeenTimestamp)}\n`;
-      }
-      result += '\n';
-    });
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
 
     result +=
       '\n' +
       'Next Steps:\n' +
-      (numProblems == 0
+      (totalNumProblems == 0
         ? '* Verify that the filters such as entitySelector, status and time range were correct, and search again with different filters.\n'
         : '') +
-      (isLimited ? '* Use more restrictive filters, such as a more specific entitySelector and status.\n' : '') +
-      (numProblems > 1 ? '* Use sort (e.g. with "-riskAssessment.riskScore" for highest risk score first).\n' : '') +
+      (anyLimited ? '* Use more restrictive filters, such as a more specific entitySelector and status.\n' : '') +
+      (totalNumProblems > 1
+        ? '* Use sort (e.g. with "-riskAssessment.riskScore" for highest risk score first).\n'
+        : '') +
       '* If the user is interested in a specific vulnerability, use the get_security_problem_details tool. Use the securityProblemId for this.\n' +
-      '* Suggest to the user that they view the security vulnerabilties in the Dynatrace UI at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/security/overview for an overview,` +
-      `or ${this.authClient.dashboardBaseUrl}/ui/security/vulnerabilities for a list of third-party vulnerabilties` +
-      '\n';
+      '* Suggest to the user that they view the security vulnerabilties in the Dynatrace UI' +
+      (baseUrl
+        ? ` at ${baseUrl}/ui/security/overview for an overview, or ${baseUrl}/ui/security/vulnerabilities for a list of third-party vulnerabilities`
+        : '.');
 
     return result;
   }
 
-  formatDetails(response: any): string {
-    let result =
-      'Details of security problem in the following json.\n' +
-      JSON.stringify(response) +
-      '\n' +
+  formatDetails(responses: Map<string, any>): string {
+    let result = '';
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      result +=
+        'Details of security problem from environment ' +
+        alias +
+        ' in the following json:\n' +
+        JSON.stringify(data) +
+        '\n';
+    }
+
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
+
+    result +=
       'Next Steps:\n' +
       '* If there are affectedEntities, suggest to the user that they could get further information about those entities with get_entity_detais tool, using the entityId.\n' +
-      '* Suggest to the user that they view the security vulnerability in the Dynatrace UI ' +
-      `${this.authClient.dashboardBaseUrl}/ui/security/vulnerabilities/<securityProblemId>, using the securityProblemId in the URL\n`;
+      '* Suggest to the user that they view the security vulnerability in the Dynatrace UI using the securityProblemId in the URL\n' +
+      (baseUrl
+        ? ` at ${baseUrl}/ui/security/vulnerabilities/<securityProblemId>, using the securityProblemId in the URL\n`
+        : '.');
 
     return result;
   }

--- a/src/capabilities/slo-api.ts
+++ b/src/capabilities/slo-api.ts
@@ -1,4 +1,4 @@
-import { ManagedAuthClient } from '../authentication/managed-auth-client.js';
+import { ManagedAuthClientManager } from '../authentication/managed-auth-client.js';
 
 import { logger } from '../utils/logger';
 
@@ -69,9 +69,9 @@ export class SloApiClient {
   static readonly API_PAGE_SIZE = 200;
   static readonly MAX_MANAGEMENT_ZONES_DISPLAY = 11;
 
-  constructor(private authClient: ManagedAuthClient) {}
+  constructor(private authManager: ManagedAuthClientManager) {}
 
-  async listSlos(params: SloQueryParams = {}): Promise<ListSlosResponse> {
+  async listSlos(params: SloQueryParams = {}, environment_aliases: string): Promise<Map<string, ListSlosResponse>> {
     const queryParams: Record<string, any> = {
       pageSize: params.pageSize || SloApiClient.API_PAGE_SIZE,
       ...(params.sloSelector && { sloSelector: params.sloSelector }),
@@ -85,12 +85,12 @@ export class SloApiClient {
       ...(params.sort && { sort: params.sort }),
     };
 
-    const response = await this.authClient.makeRequest('/api/v2/slo', queryParams);
-    logger.debug('listSLOs response', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests('/api/v2/slo', queryParams, environment_aliases);
+    logger.debug('listSLOs response', { data: responses });
+    return responses;
   }
 
-  async getSloDetails(params: GetSloQueryParams): Promise<any> {
+  async getSloDetails(params: GetSloQueryParams, environment_aliases: string): Promise<Map<string, any>> {
     const queryParams: Record<string, any> = {
       ...(params.from && { from: params.from }),
       ...(params.to && { to: params.to }),
@@ -100,78 +100,93 @@ export class SloApiClient {
       queryParams.timeFrame = 'GTF';
     }
 
-    const response = await this.authClient.makeRequest(`/api/v2/slo/${encodeURIComponent(params.id)}`, queryParams);
-    logger.debug('getSLODetails response', { data: response });
-    return response;
+    const responses = await this.authManager.makeRequests(
+      `/api/v2/slo/${encodeURIComponent(params.id)}`,
+      queryParams,
+      environment_aliases,
+    );
+    logger.debug('getSLODetails response', { data: responses });
+    return responses;
   }
 
-  formatList(response: ListSlosResponse): string {
-    let totalCount = response.totalCount || -1;
-    let numSLOs = response.slo?.length || 0;
-    let isLimited = totalCount != 0 - 1 && totalCount > numSLOs;
+  formatList(responses: Map<string, ListSlosResponse>): string {
+    let result = '';
+    let totalNumSlo = 0;
+    let anyLimited = false;
+    let aliases: string[] = [];
+    for (const [alias, data] of responses) {
+      aliases.push(alias);
+      let totalCount = data.totalCount || -1;
+      let numSLOs = data.slo?.length || 0;
+      totalNumSlo += numSLOs;
+      let isLimited = totalCount != 0 - 1 && totalCount > numSLOs;
 
-    let result = 'Listing ' + numSLOs + (totalCount == -1 ? '' : ' of ' + totalCount) + ' SLOs.\n';
-
-    if (isLimited) {
       result +=
-        'Not showing all matching SLOs. Consider using more specific filters (sloSelector) to get complete results.\n';
+        'Listing ' +
+        numSLOs +
+        (totalCount == -1 ? '' : ' of ' + totalCount) +
+        ' SLOs from environment ' +
+        alias +
+        ':\n';
+
+      if (isLimited) {
+        result +=
+          'Not showing all matching SLOs. Consider using more specific filters (sloSelector) to get complete results.\n';
+        anyLimited = true;
+      }
+
+      data.slo?.forEach((slo: any) => {
+        result += `id: ${slo.id}\n`;
+        result += `  name: ${slo.name}\n`;
+        if (slo.description) {
+          result += `${slo.description}\n`;
+        }
+        result += `  status: ${slo.status}\n`;
+        result += `  target: ${slo.target}\n`;
+        result += `  warning: ${slo.warning}\n`;
+        result += `  enabled: ${slo.enabled}\n`;
+        if (slo.timeframe) {
+          result += `. timeframe: ${slo.timeframe}\n`;
+        }
+        if (slo.evaluatedPercentage !== undefined && slo.evaluatedPercentage !== -1) {
+          result += `. evaluatedPercentage: ${slo.evaluatedPercentage}%\n`;
+        }
+        if (slo.errorBudget !== undefined && slo.errorBudget !== -1) {
+          result += `  error budget: ${slo.errorBudget}%\n`;
+        }
+        if (slo.managementZones && slo.managementZones.length > 0) {
+          const zones = slo.managementZones
+            .slice(0, SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY)
+            .map((zone: any) => zone.name || zone.id || zone)
+            .join(', ');
+          result += `  management zones: ${zones}${slo.managementZones.length > SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY ? ` (+${slo.managementZones.length - SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY} more)` : ''}\n`;
+        }
+        result += '\n';
+      });
     }
 
-    response.slo?.forEach((slo: any) => {
-      result += `id: ${slo.id}\n`;
-      result += `  name: ${slo.name}\n`;
-      if (slo.description) {
-        result += `${slo.description}\n`;
-      }
-      result += `  status: ${slo.status}\n`;
-      result += `  target: ${slo.target}\n`;
-      result += `  warning: ${slo.warning}\n`;
-      result += `  enabled: ${slo.enabled}\n`;
-      if (slo.timeframe) {
-        result += `. timeframe: ${slo.timeframe}\n`;
-      }
-      if (slo.evaluatedPercentage !== undefined && slo.evaluatedPercentage !== -1) {
-        result += `. evaluatedPercentage: ${slo.evaluatedPercentage}%\n`;
-      }
-      if (slo.errorBudget !== undefined && slo.errorBudget !== -1) {
-        result += `  error budget: ${slo.errorBudget}%\n`;
-      }
-      if (slo.managementZones && slo.managementZones.length > 0) {
-        const zones = slo.managementZones
-          .slice(0, SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY)
-          .map((zone: any) => zone.name || zone.id || zone)
-          .join(', ');
-        result += `  management zones: ${zones}${slo.managementZones.length > SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY ? ` (+${slo.managementZones.length - SloApiClient.MAX_MANAGEMENT_ZONES_DISPLAY} more)` : ''}\n`;
-      }
-      result += '\n';
-    });
+    const baseUrl = aliases.length == 1 ? this.authManager.getBaseUrl(aliases[0]) : '';
 
     result +=
       '\n' +
       'Next Steps:\n' +
-      (numSLOs == 0
+      (totalNumSlo == 0
         ? '* Verify that the filters such as sloSelector were correct, and search again with different filters.\n'
         : '') +
-      (isLimited ? '* Use more restrictive filters, such as a more specific sloSelector and status.\n' : '') +
-      (numSLOs > 1 ? '* Use sort (e.g. with "+name" for ascending alphabetical order).\n' : '') +
+      (anyLimited ? '* Use more restrictive filters, such as a more specific sloSelector and status.\n' : '') +
+      (totalNumSlo > 1 ? '* Use sort (e.g. with "+name" for ascending alphabetical order).\n' : '') +
       '* If the user is interested in a specific SLO, use the get_slo_details tool. Use the SLO id for this.\n' +
-      '* Suggest to the user that they view the SLOs in the Dynatrace UI at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/slo` +
-      '\n';
-
+      '* Suggest to the user that they view the SLOs in the Dynatrace UI' +
+      (baseUrl ? ` at ${baseUrl}/ui/slo` : '.');
     return result;
   }
 
-  formatDetails(response: any): string {
-    let result =
-      'Details of SLO in the following json.\n' +
-      JSON.stringify(response) +
-      '\n' +
-      'Next Steps:\n' +
-      '* Suggest to the user that they view the SLO in the Dynatrace UI at ' +
-      `${this.authClient.dashboardBaseUrl}/ui/slo/<id>, using the SLO id in the URL` +
-      '\n';
-
+  formatDetails(responses: Map<string, any>): string {
+    let result = '';
+    for (const [alias, data] of responses) {
+      result += 'Details of SLO from environment ' + alias + ' in the following json:\n' + JSON.stringify(data) + '\n';
+    }
+    result += 'Next Steps:\n' + '* Suggest to the user that they explore this further in the Dynatrace UI.' + '\n';
     return result;
   }
 }

--- a/src/utils/__tests__/environment.test.ts
+++ b/src/utils/__tests__/environment.test.ts
@@ -1,7 +1,49 @@
-import { getManagedEnvironmentConfig } from '../environment';
+import { getManagedEnvironmentConfigs, validateEnvironments } from '../environment';
 
 describe('getManagedEnvironmentConfig', () => {
   const originalEnv = process.env;
+  const fullEnv =
+    '[' +
+    '{' +
+    '    "dynatraceUrl": "https://my-dashboard-endpoint.com/",' +
+    '    "apiEndpointUrl": "https://my-api-endpoint.com/",' +
+    '    "environmentId": "my-env-id-1",' +
+    '    "alias": "alias-env-id-1",' +
+    '    "apiToken": "my-api-token",' +
+    '    "httpsProxyUrl": ""' +
+    '  },' +
+    '  {' +
+    '    "dynatraceUrl": "https://my-dashboard-endpoint.com",' +
+    '    "apiEndpointUrl": "https://my-api-endpoint.com",' +
+    '    "environmentId": "my-env-id-2",' +
+    '    "alias": "invalid-alias-env-id;-2",' +
+    '    "apiToken": "my-api-token",' +
+    '    "httpProxyUrl": "",' +
+    '    "httpsProxyUrl": ""' +
+    '  },' +
+    '  {' +
+    '    "dynatraceUrl": "https://my-dashboard-endpoint.com",' +
+    '    "apiEndpointUrl": "https://my-api-endpoint.com",' +
+    '    "environmentId": "my-env-id-3",' +
+    '    "alias": "missing-api-key-env-id-3",' +
+    '    "httpProxyUrl": "",' +
+    '    "httpsProxyUrl": ""' +
+    '  },' +
+    '  {' +
+    '    "apiEndpointUrl": "https://my-api-endpoint.com",' +
+    '    "environmentId": "my-env-id-4",' +
+    '    "alias": "only-required-keys-env-4",' +
+    '    "apiToken": "my-api-token"' +
+    '  },' +
+    '  {' +
+    '    "dynatraceUrl": "https://my-dashboard-endpoint.com",' +
+    '    "environmentId": "my-env-id-5",' +
+    '    "alias": "missing-api-url-env-5",' +
+    '    "apiToken": "my-api-token",' +
+    '    "httpProxyUrl": "",' +
+    '    "httpsProxyUrl": ""' +
+    '  }' +
+    ']';
 
   beforeEach(() => {
     process.env = {};
@@ -11,71 +53,132 @@ describe('getManagedEnvironmentConfig', () => {
     process.env = originalEnv;
   });
 
-  it('should return config with required environment variables', () => {
-    process.env.DT_MANAGED_ENVIRONMENT = 'my-env-id';
-    process.env.DT_API_ENDPOINT_URL = 'https://my-api-endpoint.com';
-    process.env.DT_DYNATRACE_URL = 'https://my-dashboard-endpoint.com';
-    process.env.DT_MANAGED_API_TOKEN = 'my-api-token';
+  it('should return configs with environments', () => {
+    process.env.DT_ENVIRONMENT_CONFIGS = fullEnv;
 
-    const config = getManagedEnvironmentConfig();
+    const config = getManagedEnvironmentConfigs();
+    expect(config).toEqual([
+      {
+        environmentId: 'my-env-id-1',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-1',
+        dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-1',
+        apiToken: 'my-api-token',
+        alias: 'alias-env-id-1',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+      {
+        environmentId: 'my-env-id-2',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-2',
+        dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-2',
+        apiToken: 'my-api-token',
+        alias: 'invalid-alias-env-id;-2',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+      {
+        environmentId: 'my-env-id-3',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-3',
+        dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-3',
+        apiToken: '',
+        alias: 'missing-api-key-env-id-3',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+      {
+        environmentId: 'my-env-id-4',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
+        dashboardUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
+        apiToken: 'my-api-token',
+        alias: 'only-required-keys-env-4',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+      {
+        environmentId: 'my-env-id-5',
+        dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-5',
+        apiUrl: '',
+        apiToken: 'my-api-token',
+        alias: 'missing-api-url-env-5',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+    ]);
+  });
 
-    expect(config).toEqual({
-      environmentId: 'my-env-id',
-      apiUrl: 'https://my-api-endpoint.com/e/my-env-id',
-      dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id',
-      apiToken: 'my-api-token',
-    });
+  it('should return only valid environments', () => {
+    process.env.DT_ENVIRONMENT_CONFIGS = fullEnv;
+
+    const config = getManagedEnvironmentConfigs();
+    const validatedConfigs = validateEnvironments(config);
+
+    const validConfigs = validatedConfigs['valid_configs'];
+    const errors = validatedConfigs['errors'];
+
+    expect(validConfigs).toEqual([
+      {
+        environmentId: 'my-env-id-1',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-1',
+        dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-1',
+        apiToken: 'my-api-token',
+        alias: 'alias-env-id-1',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+      {
+        environmentId: 'my-env-id-4',
+        apiUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
+        dashboardUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
+        apiToken: 'my-api-token',
+        alias: 'only-required-keys-env-4',
+        httpProxy: '',
+        httpsProxy: '',
+      },
+    ]);
+
+    expect(errors).toEqual([
+      'Invalid alias found: "invalid-alias-env-id;-2". Aliases are mandatory and cannot contain semicolons.',
+      'Key "apiToken" is empty or missing (environment #2, alias: missing-api-key-env-id-3). Please make sure all values are present and populated in the configuration array.',
+      'Key "apiEndpointUrl" is empty or missing (environment #4, alias: missing-api-url-env-5). Please make sure all values are present and populated in the configuration array.',
+    ]);
+  });
+
+  it('should throw error when DT_ENVIRONMENT_CONFIGS is missing', () => {
+    process.env = {};
+    expect(() => getManagedEnvironmentConfigs()).toThrow('DT_ENVIRONMENT_CONFIGS is required');
   });
 
   it('should remove trailing slash from environment URL', () => {
-    process.env.DT_MANAGED_ENVIRONMENT = 'my-env-id/';
-    process.env.DT_API_ENDPOINT_URL = 'https://my-api-endpoint.com/';
-    process.env.DT_DYNATRACE_URL = 'https://my-dashboard-endpoint.com/';
-    process.env.DT_MANAGED_API_TOKEN = 'my-api-token';
+    process.env.DT_ENVIRONMENT_CONFIGS = fullEnv;
+    const config = getManagedEnvironmentConfigs();
+    const validatedConfigs = validateEnvironments(config);
+    const validConfigWithTrailingSlash = validatedConfigs['valid_configs'][0];
 
-    const config = getManagedEnvironmentConfig();
-
-    expect(config).toEqual({
-      environmentId: 'my-env-id',
-      apiUrl: 'https://my-api-endpoint.com/e/my-env-id',
-      dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id',
+    expect(validConfigWithTrailingSlash).toEqual({
+      environmentId: 'my-env-id-1',
+      apiUrl: 'https://my-api-endpoint.com/e/my-env-id-1',
+      dashboardUrl: 'https://my-dashboard-endpoint.com/e/my-env-id-1',
       apiToken: 'my-api-token',
+      alias: 'alias-env-id-1',
+      httpProxy: '',
+      httpsProxy: '',
     });
   });
 
   it('should default dashboard url to api base url', () => {
-    process.env.DT_MANAGED_ENVIRONMENT = 'my-env-id';
-    process.env.DT_API_ENDPOINT_URL = 'https://my-endpoint.com';
-    process.env.DT_MANAGED_API_TOKEN = 'my-api-token';
+    process.env.DT_ENVIRONMENT_CONFIGS = fullEnv;
+    const config = getManagedEnvironmentConfigs();
+    const validatedConfigs = validateEnvironments(config);
+    const validConfigOnlyRequiredFields = validatedConfigs['valid_configs'][1];
 
-    const config = getManagedEnvironmentConfig();
-
-    expect(config).toEqual({
-      environmentId: 'my-env-id',
-      apiUrl: 'https://my-endpoint.com/e/my-env-id',
-      dashboardUrl: 'https://my-endpoint.com/e/my-env-id',
+    expect(validConfigOnlyRequiredFields).toEqual({
+      environmentId: 'my-env-id-4',
+      apiUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
+      dashboardUrl: 'https://my-api-endpoint.com/e/my-env-id-4',
       apiToken: 'my-api-token',
+      alias: 'only-required-keys-env-4',
+      httpProxy: '',
+      httpsProxy: '',
     });
-  });
-
-  it('should throw error when DT_MANAGED_ENVIRONMENT is missing', () => {
-    process.env.DT_API_ENDPOINT_URL = 'https://my-api-endpoint.com/';
-    process.env.DT_MANAGED_API_TOKEN = 'my-api-token';
-
-    expect(() => getManagedEnvironmentConfig()).toThrow('DT_MANAGED_ENVIRONMENT is required');
-  });
-
-  it('should throw error when DT_API_ENDPOINT_URL is missing', () => {
-    process.env.DT_MANAGED_ENVIRONMENT = 'my-env-id';
-    process.env.DT_MANAGED_API_TOKEN = 'my-api-token';
-
-    expect(() => getManagedEnvironmentConfig()).toThrow('DT_API_ENDPOINT_URL is required');
-  });
-
-  it('should throw error when DT_MANAGED_API_TOKEN is missing', () => {
-    process.env.DT_MANAGED_ENVIRONMENT = 'my-env-id';
-    process.env.DT_API_ENDPOINT_URL = 'https://my-endpoint.com';
-
-    expect(() => getManagedEnvironmentConfig()).toThrow('DT_MANAGED_API_TOKEN is required');
   });
 });

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,30 +1,29 @@
+import { JSONObject } from '@dynatrace/openkit-js';
+
 export interface ManagedEnvironmentConfig {
   environmentId: string;
   apiUrl: string;
   dashboardUrl: string;
   apiToken: string;
+  alias: string;
+  httpProxy?: string;
+  httpsProxy?: string;
 }
 
-export function getManagedEnvironmentConfig(): ManagedEnvironmentConfig {
-  const environmentIdRaw = process.env.DT_MANAGED_ENVIRONMENT;
-  const apiUrlRaw = process.env.DT_API_ENDPOINT_URL;
-  const dashboardUrlRaw = process.env.DT_DYNATRACE_URL;
-  const apiToken = process.env.DT_MANAGED_API_TOKEN;
-
-  if (!environmentIdRaw) {
-    throw new Error('DT_MANAGED_ENVIRONMENT is required');
-  }
-
-  if (!apiUrlRaw) {
-    throw new Error('DT_API_ENDPOINT_URL is required');
-  }
-
-  if (!apiToken) {
-    throw new Error('DT_MANAGED_API_TOKEN is required');
-  }
+export function parseManagedEnvironmentConfig(environmentInfo: JSONObject): ManagedEnvironmentConfig {
+  const environmentIdRaw = environmentInfo.environmentId ? environmentInfo.environmentId.toString() : '';
+  const apiUrlRaw = environmentInfo.apiEndpointUrl ? environmentInfo.apiEndpointUrl.toString() : '';
+  const dashboardUrlRaw = environmentInfo.dynatraceUrl ? environmentInfo.dynatraceUrl.toString() : '';
+  const apiToken = environmentInfo.apiToken ? environmentInfo.apiToken.toString() : '';
+  const alias = environmentInfo.alias ? environmentInfo.alias.toString() : '';
+  const httpProxy = environmentInfo.httpProxyUrl ? environmentInfo.httpProxyUrl.toString() : '';
+  const httpsProxy = environmentInfo.httpsProxyUrl ? environmentInfo.httpsProxyUrl.toString() : '';
 
   let environmentId = environmentIdRaw.replace(/\/$/, ''); // Remove trailing slash
-  let apiUrl = apiUrlRaw + (apiUrlRaw.endsWith('/') ? '' : '/') + 'e/' + environmentId;
+  let apiUrl = '';
+  if (apiUrlRaw != '') {
+    apiUrl = apiUrlRaw + (apiUrlRaw.endsWith('/') ? '' : '/') + 'e/' + environmentId;
+  }
   let dashboardUrl = dashboardUrlRaw ? dashboardUrlRaw : apiUrlRaw;
   dashboardUrl = dashboardUrl + (dashboardUrl.endsWith('/') ? '' : '/') + 'e/' + environmentId;
 
@@ -33,5 +32,70 @@ export function getManagedEnvironmentConfig(): ManagedEnvironmentConfig {
     apiUrl: apiUrl,
     dashboardUrl: dashboardUrl,
     apiToken: apiToken,
+    alias: alias,
+    httpProxy: httpProxy,
+    httpsProxy: httpsProxy,
   };
+}
+
+export function getManagedEnvironmentConfigs(): ManagedEnvironmentConfig[] {
+  const environmentConfigs = process.env.DT_ENVIRONMENT_CONFIGS;
+  if (!environmentConfigs) {
+    throw new Error('DT_ENVIRONMENT_CONFIGS is required');
+  }
+  let environmentConfigurations;
+  try {
+    environmentConfigurations = JSON.parse(environmentConfigs);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      throw new Error(`JSON syntax error in environment file: ${e}`);
+    } else {
+      throw e;
+    }
+  }
+  let parsedManagedEnvironmentConfigs: ManagedEnvironmentConfig[] = [];
+  for (const environmentConfig of environmentConfigurations) {
+    parsedManagedEnvironmentConfigs.push(parseManagedEnvironmentConfig(environmentConfig));
+  }
+  return parsedManagedEnvironmentConfigs;
+}
+
+export function validateEnvironments(environmentConfigurations: ManagedEnvironmentConfig[]): {
+  valid_configs: ManagedEnvironmentConfig[];
+  errors: string[];
+} {
+  const requiredKeys = ['apiUrl', 'environmentId', 'alias', 'apiToken'];
+  const originalKeys = {
+    apiUrl: 'apiEndpointUrl',
+    environmentId: 'environmentId',
+    alias: 'alias',
+    apiToken: 'apiToken',
+  };
+  let validConfigurations: ManagedEnvironmentConfig[] = [];
+  let errors: string[] = [];
+
+  environmentConfigurations.forEach((configuration, index) => {
+    const hasAllValues = requiredKeys.every((key) => {
+      const value = configuration[key as keyof typeof configuration];
+
+      const isValid = value && value.length > 0;
+      if (!isValid) {
+        errors.push(
+          `Key "${originalKeys[key as keyof typeof originalKeys]}" is empty or missing (environment #${index}, alias: ${configuration.alias ? configuration.alias : 'N/A'}). Please make sure all values are present and populated in the configuration array.`,
+        );
+      }
+      return isValid;
+    });
+    const validAlias = configuration.alias.indexOf(';') == -1;
+    if (!validAlias) {
+      errors.push(
+        'Invalid alias found: "' + configuration.alias + '". Aliases are mandatory and cannot contain semicolons.',
+      );
+    }
+    if (validAlias && hasAllValues) {
+      validConfigurations.push(configuration);
+    }
+  });
+
+  return { valid_configs: validConfigurations, errors: errors };
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -9,3 +9,7 @@ export const logger = winston.createLogger({
   ),
   transports: [new winston.transports.File({ filename: 'dynatrace-managed-mcp.log' })],
 });
+export async function flushLogger() {
+  logger.end();
+  await new Promise((resolve) => logger.once('finish', resolve));
+}

--- a/tests/integration/proxy.integration.test.ts
+++ b/tests/integration/proxy.integration.test.ts
@@ -49,13 +49,15 @@ describe('ProxyConfig', () => {
   it(
     'should use HTTP_PROXY',
     async () => {
-      process.env.HTTP_PROXY = proxyUrl;
-
       let client = new ManagedAuthClient({
         apiBaseUrl: 'http://example.com',
         dashboardBaseUrl: 'http://example-dashboard.com',
         apiToken: 'my-example-token',
+        alias: 'alias',
+        httpsProxy: proxyUrl,
+        minimum_version: '1.328.0',
       });
+
       const response = await client.makeRequest('/anything/mypath');
 
       console.log(`response: ${JSON.stringify(response)}`);

--- a/tests/integration/sorting-parameters.integration.test.ts
+++ b/tests/integration/sorting-parameters.integration.test.ts
@@ -7,142 +7,162 @@ import { ProblemsApiClient } from '../../src/capabilities/problems-api';
 import { SecurityApiClient } from '../../src/capabilities/security-api';
 import { SloApiClient } from '../../src/capabilities/slo-api';
 import { LogsApiClient } from '../../src/capabilities/logs-api';
-import { ManagedAuthClient } from '../../src/authentication/managed-auth-client';
-import { getManagedEnvironmentConfig } from '../../src/utils/environment';
+import { ManagedAuthClientManager } from '../../src/authentication/managed-auth-client';
+import { getManagedEnvironmentConfigs, validateEnvironments } from '../../src/utils/environment';
 import { config } from 'dotenv';
+import { MetricsApiClient } from '../../src/capabilities/metrics-api';
+import { EventsApiClient } from '../../src/capabilities/events-api';
 
 // Load environment variables
 config();
 
 let skip = false;
-if (!process.env.DT_MANAGED_ENVIRONMENT || !process.env.DT_API_ENDPOINT_URL || !process.env.DT_MANAGED_API_TOKEN) {
+if (!process.env.DT_ENVIRONMENT_CONFIGS) {
   console.log('Skipping integration tests - environment not configured');
   skip = true;
 }
 
 (skip ? describe.skip : describe)('Sorting Parameters Integration Tests', () => {
-  let authClient: ManagedAuthClient;
+  let metricsClient: MetricsApiClient;
+  let logsClient: LogsApiClient;
+  let eventsClient: EventsApiClient;
   let entitiesClient: EntitiesApiClient;
   let problemsClient: ProblemsApiClient;
   let securityClient: SecurityApiClient;
   let sloClient: SloApiClient;
-  let logsClient: LogsApiClient;
 
   beforeAll(() => {
-    const config = getManagedEnvironmentConfig();
-    authClient = new ManagedAuthClient({
-      apiBaseUrl: config.apiUrl,
-      dashboardBaseUrl: config.dashboardUrl,
-      apiToken: config.apiToken,
-    });
-    entitiesClient = new EntitiesApiClient(authClient);
-    problemsClient = new ProblemsApiClient(authClient);
-    securityClient = new SecurityApiClient(authClient);
-    sloClient = new SloApiClient(authClient);
-    logsClient = new LogsApiClient(authClient);
-  });
+    const config = getManagedEnvironmentConfigs();
+    const validEnvironments = validateEnvironments(config);
 
+    const authManager = new ManagedAuthClientManager(validEnvironments['valid_configs']);
+
+    metricsClient = new MetricsApiClient(authManager);
+    logsClient = new LogsApiClient(authManager);
+    eventsClient = new EventsApiClient(authManager);
+    entitiesClient = new EntitiesApiClient(authManager);
+    problemsClient = new ProblemsApiClient(authManager);
+    securityClient = new SecurityApiClient(authManager);
+    sloClient = new SloApiClient(authManager);
+  });
   describe('Entities API Sorting', () => {
     it('should accept ascending sort parameter', async () => {
       await expect(
-        entitiesClient.queryEntities({
-          entitySelector: 'type(HOST)',
-          pageSize: 5,
-          sort: '+name',
-        }),
+        entitiesClient.queryEntities(
+          {
+            entitySelector: 'type(HOST)',
+            pageSize: 5,
+            sort: '+name',
+          },
+          'testAlias',
+        ),
       ).resolves.not.toThrow();
     });
 
     it('should accept descending sort parameter', async () => {
       await expect(
-        entitiesClient.queryEntities({
-          entitySelector: 'type(SERVICE)',
-          pageSize: 5,
-          sort: '-name',
-        }),
+        entitiesClient.queryEntities(
+          {
+            entitySelector: 'type(SERVICE)',
+            pageSize: 5,
+            sort: '-name',
+          },
+          'testAlias',
+        ),
       ).resolves.not.toThrow();
     });
 
     it('should work without sort parameter (backward compatibility)', async () => {
       await expect(
-        entitiesClient.queryEntities({
-          entitySelector: 'type(HOST)',
-          pageSize: 5,
-        }),
+        entitiesClient.queryEntities(
+          {
+            entitySelector: 'type(HOST)',
+            pageSize: 5,
+          },
+          'testAlias',
+        ),
       ).resolves.not.toThrow();
     });
   });
 
   describe('Problems API Sorting', () => {
     it('should accept ascending sort parameter', async () => {
-      await expect(problemsClient.listProblems({ sort: '+startTime', pageSize: 5 })).resolves.not.toThrow();
+      await expect(
+        problemsClient.listProblems({ sort: '+startTime', pageSize: 5 }, 'testAlias'),
+      ).resolves.not.toThrow();
     });
 
     it('should accept descending sort parameter', async () => {
-      await expect(problemsClient.listProblems({ sort: '-startTime', pageSize: 5 })).resolves.not.toThrow();
+      await expect(
+        problemsClient.listProblems({ sort: '-startTime', pageSize: 5 }, 'testAlias'),
+      ).resolves.not.toThrow();
     });
 
     it('should work without sort parameter (backward compatibility)', async () => {
-      await expect(problemsClient.listProblems({ pageSize: 5 })).resolves.not.toThrow();
+      await expect(problemsClient.listProblems({ pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
   });
 
   describe('Security API Sorting', () => {
     it('should accept ascending sort parameter', async () => {
-      await expect(securityClient.listSecurityProblems({ sort: '+riskAssessment.riskScore' })).resolves.not.toThrow();
+      await expect(
+        securityClient.listSecurityProblems({ sort: '+riskAssessment.riskScore' }, 'testAlias'),
+      ).resolves.not.toThrow();
     });
 
     it('should accept descending sort parameter', async () => {
-      await expect(securityClient.listSecurityProblems({ sort: '-riskAssessment.riskScore' })).resolves.not.toThrow();
+      await expect(
+        securityClient.listSecurityProblems({ sort: '-riskAssessment.riskScore' }, 'testAlias'),
+      ).resolves.not.toThrow();
     });
 
     it('should work without sort parameter (backward compatibility)', async () => {
-      await expect(securityClient.listSecurityProblems()).resolves.not.toThrow();
+      await expect(securityClient.listSecurityProblems(undefined, 'testAlias')).resolves.not.toThrow();
     });
   });
 
   describe('SLO API Sorting', () => {
     it('should accept ascending sort parameter', async () => {
-      await expect(sloClient.listSlos({ sort: 'name', pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ sort: 'name', pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
 
     it('should accept descending sort parameter', async () => {
-      await expect(sloClient.listSlos({ sort: '-name', pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ sort: '-name', pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
 
     it('should work without sort parameter (backward compatibility)', async () => {
-      await expect(sloClient.listSlos({ pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
 
     it('should accept evaluate parameter', async () => {
-      await expect(sloClient.listSlos({ evaluate: true, pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ evaluate: true, pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
 
     it('should accept enabledSlos parameter', async () => {
-      await expect(sloClient.listSlos({ enabledSlos: 'true', pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ enabledSlos: 'true', pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
 
     it('should accept showGlobalSlos parameter', async () => {
-      await expect(sloClient.listSlos({ showGlobalSlos: false, pageSize: 5 })).resolves.not.toThrow();
+      await expect(sloClient.listSlos({ showGlobalSlos: false, pageSize: 5 }, 'testAlias')).resolves.not.toThrow();
     });
   });
 
   describe('Logs Sorting', () => {
     it('should accept ascending sort parameter', async () => {
       await expect(
-        logsClient.queryLogs({ sort: '+timestamp', query: 'error', from: 'now-1h', to: 'now', limit: 5 }),
+        logsClient.queryLogs({ sort: '+timestamp', query: 'error', from: 'now-1h', to: 'now', limit: 5 }, 'testAlias'),
       ).resolves.not.toThrow();
     });
 
     it('should accept descending sort parameter', async () => {
       await expect(
-        logsClient.queryLogs({ sort: '-timestamp', query: 'error', from: 'now-1h', to: 'now', limit: 5 }),
+        logsClient.queryLogs({ sort: '-timestamp', query: 'error', from: 'now-1h', to: 'now', limit: 5 }, 'testAlias'),
       ).resolves.not.toThrow();
     });
 
     it('should work without sort parameter (backward compatibility)', async () => {
       await expect(
-        logsClient.queryLogs({ query: 'error', from: 'now-1h', to: 'now', limit: 5 }),
+        logsClient.queryLogs({ query: 'error', from: 'now-1h', to: 'now', limit: 5 }, 'testAlias'),
       ).resolves.not.toThrow();
     });
   });


### PR DESCRIPTION
Addresses https://github.com/dynatrace-oss/dynatrace-managed-mcp/issues/16: Support multiple Dynatrace Managed environments in a single MCP Server instance

Note this is a "breaking change", it is not backwards compatible. It changes the expected environment variables.

@ivan-gudak : can you review please?

--
Tip: when reviewing the PR changes, use `?w=1`. This ignores white-space. Quite a few lines change because of change in indentation. This is because we loop over each environment, e.g. in `formatList` methods (so the original code is now indented in a for loop).