### PR TITLE
ISSUE54 implement flexible logging configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,18 @@
 # Proxy configuration optional (for corporate environments)
 # Mandatory keys are: "apiEndpointUrl", "environmentId", "alias" and "apiToken"
 
+## Logging Configuration (optional)
+# LOG_LEVEL: Log verbosity level (debug, info, warn, error). Default: info
+# LOG_OUTPUT: Where to send logs. Options:
+#   - file (default): Write to log file
+#   - stdout / console: Write to standard output
+#   - stderr: Write errors/warnings to standard error
+#   - stderr-all: Write all logs to standard error
+#   - file+console / file+stdout: Write to both file and stdout
+#   - file+stderr: Write to file and errors/warnings to stderr
+#   - disabled: No logging
+# LOG_FILE: Path to log file (only used when LOG_OUTPUT includes 'file'). Default: dynatrace-managed-mcp.log
+
 DT_ENVIRONMENT_CONFIGS='[
   {
     "dynatraceUrl": "https://my-dashboard-endpoint.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased Changes
 
+- Improved logging configuration with comprehensive environment variables `LOG_OUTPUT` and `LOG_FILE`, providing greater flexibility for log destinations. You can now:
+  - Redirect logs to stdout (`stdout` or `console`), stderr (errors/warnings only with `stderr`, or all levels with `stderr-all`), or a custom file path
+  - Use multiple destinations simultaneously (e.g., `file+console` to log to both file and stdout, or `file+stderr` for file logging with errors to stderr)
+  - Disable logging entirely with `disabled`
+
 ## 0.5.3
 
 - Add multi-environment support, enabling you to connect to multiple Dynatrace Managed deployments simultaneously through a unified configuration

--- a/README.md
+++ b/README.md
@@ -361,7 +361,39 @@ AWS Lambda Functions:
 ## Environment Variables
 
 - `DT_ENVIRONMENT_CONFIGS`: An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to. See below for contents of this.
-- `LOG_LEVEL` (optional): Log level, writing to dynatrace-managed-mcp.log in the current working directory (e.g. debug, info, warning, error)
+- `LOG_LEVEL` (optional): Log verbosity level (e.g. debug, info, warn, error). Default: `info`
+- `LOG_OUTPUT` (optional): Log output destination. Options:
+  - `file` (default): Write logs to a file
+  - `stdout`: Write logs to standard output
+  - `console`: Alias for `stdout`
+  - `stderr`: Write errors and warnings to standard error (info/debug still suppressed)
+  - `stderr-all`: Write all log levels to standard error
+  - `file+console` or `file+stdout`: Write logs to both file and stdout
+  - `file+stderr`: Write logs to file and errors/warnings to stderr
+  - `disabled`: Disable logging entirely
+- `LOG_FILE` (optional): Path to log file when `LOG_OUTPUT` includes `file`. Default: `dynatrace-managed-mcp.log` in current working directory
+
+**Logging Examples:**
+
+```bash
+# Log to standard output (useful for Docker/containerized environments)
+LOG_OUTPUT=stdout node dist/index.js
+
+# Log errors/warnings to stderr, suppress info/debug (standard Unix practice)
+LOG_OUTPUT=stderr node dist/index.js
+
+# Log to custom file path
+LOG_OUTPUT=file LOG_FILE=/var/log/dynatrace-mcp.log node dist/index.js
+
+# Log to both file and console (useful for debugging)
+LOG_OUTPUT=file+console LOG_LEVEL=debug node dist/index.js
+
+# Log to file, send errors/warnings to stderr (production use)
+LOG_OUTPUT=file+stderr LOG_FILE=/var/log/app.log node dist/index.js
+
+# Disable logging entirely (not recommended)
+LOG_OUTPUT=disabled node dist/index.js
+```
 
 ### Multienvironment Config Fields
 

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,157 @@
+import winston from 'winston';
+
+describe('Logger Configuration', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    // Clear any winston instances
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should use file transport by default', () => {
+    delete process.env.LOG_OUTPUT;
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.File);
+    expect((logger.transports[0] as winston.transports.FileTransportInstance).filename).toBe(
+      'dynatrace-managed-mcp.log',
+    );
+  });
+
+  it('should use custom file path when LOG_FILE is set', () => {
+    process.env.LOG_OUTPUT = 'file';
+    process.env.LOG_FILE = 'custom-log-path.log';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.File);
+    expect((logger.transports[0] as winston.transports.FileTransportInstance).filename).toBe('custom-log-path.log');
+  });
+
+  it('should use stderr transport for errors/warnings only', () => {
+    process.env.LOG_OUTPUT = 'stderr';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.Console);
+    const stderrLevels = (logger.transports[0] as winston.transports.ConsoleTransportInstance).stderrLevels;
+    expect(stderrLevels).toBeDefined();
+    expect(stderrLevels).toHaveProperty('error');
+    expect(stderrLevels).toHaveProperty('warn');
+  });
+
+  it('should use stderr-all transport for all log levels', () => {
+    process.env.LOG_OUTPUT = 'stderr-all';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.Console);
+    const stderrLevels = (logger.transports[0] as winston.transports.ConsoleTransportInstance).stderrLevels;
+    expect(stderrLevels).toBeDefined();
+    expect(stderrLevels).toHaveProperty('info');
+    expect(stderrLevels).toHaveProperty('debug');
+  });
+
+  it('should use stdout transport when LOG_OUTPUT is console', () => {
+    process.env.LOG_OUTPUT = 'console';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.Console);
+    const transport = logger.transports[0] as winston.transports.ConsoleTransportInstance;
+    const stderrLevels = transport.stderrLevels;
+    if (stderrLevels) {
+      expect(Object.keys(stderrLevels)).toHaveLength(0);
+    }
+  });
+
+  it('should use stdout transport when LOG_OUTPUT is stdout', () => {
+    process.env.LOG_OUTPUT = 'stdout';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.Console);
+  });
+
+  it('should use both file and stdout when LOG_OUTPUT is file+console', () => {
+    process.env.LOG_OUTPUT = 'file+console';
+    process.env.LOG_FILE = 'test.log';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(2);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.File);
+    expect(logger.transports[1]).toBeInstanceOf(winston.transports.Console);
+    expect((logger.transports[0] as winston.transports.FileTransportInstance).filename).toBe('test.log');
+  });
+
+  it('should use both file and stdout when LOG_OUTPUT is file+stdout', () => {
+    process.env.LOG_OUTPUT = 'file+stdout';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(2);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.File);
+    expect(logger.transports[1]).toBeInstanceOf(winston.transports.Console);
+  });
+
+  it('should use both file and stderr when LOG_OUTPUT is file+stderr', () => {
+    process.env.LOG_OUTPUT = 'file+stderr';
+    process.env.LOG_FILE = 'combined.log';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(2);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.File);
+    expect(logger.transports[1]).toBeInstanceOf(winston.transports.Console);
+    expect((logger.transports[0] as winston.transports.FileTransportInstance).filename).toBe('combined.log');
+    const stderrLevels = (logger.transports[1] as winston.transports.ConsoleTransportInstance).stderrLevels;
+    expect(stderrLevels).toBeDefined();
+    expect(stderrLevels).toHaveProperty('error');
+    expect(stderrLevels).toHaveProperty('warn');
+  });
+
+  it('should have no transports when LOG_OUTPUT is disabled', () => {
+    process.env.LOG_OUTPUT = 'disabled';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(0);
+  });
+
+  it('should default to info log level', () => {
+    delete process.env.LOG_LEVEL;
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.level).toBe('info');
+  });
+
+  it('should respect custom log level', () => {
+    process.env.LOG_LEVEL = 'debug';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.level).toBe('debug');
+  });
+
+  it('should handle case-insensitive LOG_OUTPUT values', () => {
+    process.env.LOG_OUTPUT = 'CONSOLE';
+    jest.resetModules();
+    const { logger } = require('../logger');
+
+    expect(logger.transports).toHaveLength(1);
+    expect(logger.transports[0]).toBeInstanceOf(winston.transports.Console);
+  });
+});


### PR DESCRIPTION
**Logging Configuration**

LOG_LEVEL: Log verbosity level (debug, info, warn, error). Default: info

LOG_OUTPUT: Where to send logs. Options:
- file (default): Write to log file
- stdout / console: Write to standard output
- stderr: Write errors/warnings to standard error
- stderr-all: Write all logs to standard error
- file+console / file+stdout: Write to both file and stdout
- file+stderr: Write to file and errors/warnings to stderr
- disabled: No logging

LOG_FILE: Path to log file (only used when LOG_OUTPUT includes 'file'). Default: dynatrace-managed-mcp.log