### PR TITLE
fix: suppress TypeScript 6.0 moduleResolution deprecation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "moduleResolution": "node",
     "types": ["node", "jest"],
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "module": "CommonJS",
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

- Bumps `ignoreDeprecations` from `"5.0"` to `"6.0"` in `tsconfig.json`
- TypeScript 6.0 deprecated `moduleResolution=node10` (aliased as `"node"`) and introduced a new TS5107 error that broke the build
- This unblocks the **Build**, **Container**, **SonarCloud**, and **Snyk** CI workflows, which were all failing due to `npm run build` exiting with code 1

## Test plan

- [x] `npm run build` passes locally after the change
- [x] All 173 unit tests pass
- [x] CI Build workflow passes on this PR

## Follow-up

The proper long-term fix is to migrate `"moduleResolution": "node"` to a modern value like `"node16"` or `"bundler"`, which removes the dependency on the `ignoreDeprecations` suppression entirely. That can be done in a separate PR with proper testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)