### PR TITLE
chore: ignore dt-config.yaml to prevent accidental credential commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 .DS_Store
 
 tsconfig.tsbuildinfo
+dt-config.yaml
 
 # Token cache directory - contains sensitive OAuth tokens
 .dt-mcp/


### PR DESCRIPTION
## Summary

- Adds `dt-config.yaml` to `.gitignore`
- The file holds environment-specific settings and can contain auth tokens — it must not be committed to the repository

## Test plan

- [x] Single-line change to `.gitignore`, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)