### PR TITLE
Vulnerability/api tokens are shown on http error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -292,7 +292,6 @@ Never run queries that could return very large amounts of data, or that could be
             .trackError(error, `tool_${name}`)
             .catch((e) => logger.warn(`Failed to track error: ${e.message}`, { error: e }));
           logger.error(`Failed to run tool ${name}: ${error.message}`, { error: error });
-          logger.error(error);
           return {
             content: [{ type: 'text', text: `Error: ${error.message}` }],
             isError: true,

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,4 +1,69 @@
 import winston from 'winston';
+import axios, { AxiosError, AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { sanitizeErrors } from '../logger';
+import { TransformableInfo } from 'logform';
+
+function buildAxiosError(): AxiosError {
+  const requestConfig: InternalAxiosRequestConfig = {
+    method: 'get',
+    url: '/api/v2/metrics',
+    headers: new AxiosHeaders({ Authorization: 'Api-Token super-secret-value', Cookie: 'sso=abc123' }),
+  };
+  const response: AxiosResponse = {
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: { 'set-cookie': ['session=leak-me'] },
+    data: {},
+    config: requestConfig,
+  };
+  return new axios.AxiosError('Request failed with status code 401', 'ERR_BAD_REQUEST', requestConfig, {}, response);
+}
+
+describe('sanitizeErrors', () => {
+  it('strips config/request/response when an AxiosError is logged directly', () => {
+    const axiosError = buildAxiosError();
+    expect(JSON.stringify(axiosError)).toContain('super-secret-value');
+    expect(JSON.stringify(axiosError)).toContain('abc123');
+    const info = sanitizeErrors().transform({ ...axiosError, level: 'error' }, {}) as TransformableInfo;
+
+    expect(JSON.stringify(info)).not.toContain('super-secret-value');
+    expect(JSON.stringify(info)).not.toContain('abc123');
+    expect(JSON.stringify(info)).not.toContain('leak-me');
+    expect(info.message).toBe('Request failed with status code 401');
+  });
+
+  it('reduces a nested AxiosError in metadata (e.g. { error: err }) down to its message', () => {
+    const axiosError = buildAxiosError();
+    expect(JSON.stringify(axiosError)).toContain('super-secret-value');
+    expect(JSON.stringify(axiosError)).toContain('abc123');
+    const info = sanitizeErrors().transform(
+      { level: 'error', message: 'Failed calling endpoint', error: axiosError },
+      {},
+    ) as TransformableInfo;
+
+    expect(info.error).toBe('Request failed with status code 401');
+    expect(JSON.stringify(info)).not.toContain('super-secret-value');
+    expect(JSON.stringify(info)).not.toContain('abc123');
+  });
+
+  it('reduces any nested Error instance in metadata to its message, not just AxiosError', () => {
+    const info = sanitizeErrors().transform(
+      { level: 'warn', message: 'Something failed', error: new Error('plain failure') },
+      {},
+    ) as Record<string, unknown>;
+
+    expect(info.error).toBe('plain failure');
+  });
+
+  it('leaves non-Error metadata untouched', () => {
+    const info = sanitizeErrors().transform(
+      { level: 'debug', message: 'queryLogs response', data: { rows: [1, 2, 3] } },
+      {},
+    ) as Record<string, unknown>;
+
+    expect(info.data).toEqual({ rows: [1, 2, 3] });
+  });
+});
 
 describe('Logger Configuration', () => {
   let originalEnv: NodeJS.ProcessEnv;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,9 +2,7 @@ import winston from 'winston';
 import axios from 'axios';
 
 export const sanitizeErrors = winston.format((info) => {
-  // This shouldn't happen, since it would require developer to type in something like:
-  // logger.error(error)
-  // Where `error` is of Error type (cast to any) instead of a string
+  // In case AxiosError is passed as sole message object
   if (axios.isAxiosError(info)) {
     delete info.config;
     delete info.request;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,7 @@
 import winston from 'winston';
 import axios from 'axios';
 
-const sanitizeErrors = winston.format((info) => {
+export const sanitizeErrors = winston.format((info) => {
   // This shouldn't happen, since it would require developer to type in something like:
   // logger.error(error)
   // Where `error` is of Error type (cast to any) instead of a string

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,23 @@
 import winston from 'winston';
+import axios from 'axios';
+
+const sanitizeErrors = winston.format((info) => {
+  // This shouldn't happen, since it would require developer to type in something like:
+  // logger.error(error)
+  // Where `error` is of Error type (cast to any) instead of a string
+  if (axios.isAxiosError(info)) {
+    delete info.config;
+    delete info.request;
+    delete info.response;
+    return info;
+  }
+  for (const key of Object.keys(info)) {
+    if (info[key] instanceof Error) {
+      info[key] = info[key].message;
+    }
+  }
+  return info;
+});
 
 function createFormat(): winston.Logform.Format {
   const logOutput = (process.env.LOG_OUTPUT || 'file').toLowerCase();
@@ -17,6 +36,7 @@ function createFormat(): winston.Logform.Format {
     return winston.format.combine(
       winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
       winston.format.errors({ stack: true }),
+      sanitizeErrors(),
       winston.format.printf(({ timestamp, level, message, ...meta }) => {
         const metaStr = Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
         return `${timestamp} [${level}] ${message}${metaStr}`;
@@ -27,6 +47,7 @@ function createFormat(): winston.Logform.Format {
     return winston.format.combine(
       winston.format.timestamp(),
       winston.format.errors({ stack: true }),
+      sanitizeErrors(),
       winston.format.json(),
     );
   }

--- a/src/utils/telemetry-openkit.ts
+++ b/src/utils/telemetry-openkit.ts
@@ -112,7 +112,11 @@ class DynatraceMcpTelemetry implements Telemetry {
       action.reportValue('platform', process.platform);
       action.leaveAction();
     } catch (error) {
-      console.warn('Failed to track server start:', error);
+      if (error instanceof Error) {
+        console.warn('Failed to track server start:', error.message);
+      } else {
+        console.warn('Failed to track server start');
+      }
     }
   }
 
@@ -141,7 +145,11 @@ class DynatraceMcpTelemetry implements Telemetry {
 
       action.leaveAction();
     } catch (error) {
-      console.warn('Failed to track tool usage:', error);
+      if (error instanceof Error) {
+        console.warn('Failed to track tool usage:', error.message);
+      } else {
+        console.warn('Failed to track tool usage');
+      }
     }
   }
 
@@ -172,7 +180,11 @@ class DynatraceMcpTelemetry implements Telemetry {
       }
       action.leaveAction();
     } catch (trackingError) {
-      console.warn('Failed to track error:', trackingError);
+      if (trackingError instanceof Error) {
+        console.warn('Failed to track error:', trackingError.message);
+      } else {
+        console.warn('Failed to track error');
+      }
     }
   }
 
@@ -191,7 +203,11 @@ class DynatraceMcpTelemetry implements Telemetry {
         });
       }
     } catch (error) {
-      console.warn('Failed to shutdown usage tracking:', error);
+      if (error instanceof Error) {
+        console.warn('Failed to shutdown usage tracking:', error.message);
+      } else {
+        console.warn('Failed to shutdown usage tracking');
+      }
     }
   }
 }


### PR DESCRIPTION
Summary

  Fixes API tokens/cookies leaking into logs and telemetry via caught AxiosError objects.

  - src/utils/logger.ts: added a sanitizeErrors winston format, run after errors({ stack: true }) in both the console and file/JSON pipelines. It strips config/request/response when an AxiosError is logged
  directly (these carry Authorization/Cookie headers and response headers like Set-Cookie), and reduces any Error instance found in log metadata (e.g. { error: someError }) down to just its .message.
  - src/index.ts: removed a redundant logger.error(error) call that logged the raw error object directly — the only call site that could trigger the direct-AxiosError leak path.
  - src/utils/telemetry-openkit.ts: the four console.warn(msg, error) calls (tracking server start, tool usage, error tracking, shutdown) now narrow to error.message when error instanceof Error, and print no
  error detail otherwise — closing a separate leak path that bypassed the winston formatter entirely.