### PR TITLE
MGD-14006(chore): bump node to 26.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @dynatrace-oss/dynatrace-managed-mcp
 
+## Unreleased
+
+### Dependencies
+
+- Bumped `fast-uri` `3.1.4` -> `3.1.5`
+- Bumped `node` `26.3.1` -> `26.5.1`
+
+### Changes
+
+- Added `engine` property to `package.json` and defined `node` version to `>=26.5.1 <27`. Failure to provide proper version will result in a warning
+
+### Fixes
+
+- Fixed npm badge in `README.md` file
+
 ## 1.0.0
 
 ### Breaking changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26.3.1-alpine3.23 AS build
+FROM node:26.5.1-alpine3.23 AS build
 
 # Set working directory
 WORKDIR /app
@@ -13,7 +13,7 @@ RUN npm ci --ignore-scripts
 RUN npm run build
 
 # RUNTIME STAGE
-FROM node:26.3.1-alpine3.23
+FROM node:26.5.1-alpine3.23
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Dynatrace Managed MCP Server
 
-<h4 align="center">
+<h4>
   <a href="https://github.com/dynatrace-oss/dynatrace-managed-mcp/releases">
-    <img src="https://img.shields.io/github/release/dynatrace-oss/dynatrace-managed-mcp" />
+    <img src="https://img.shields.io/github/release/dynatrace-oss/dynatrace-managed-mcp?color=c05240" alt="Latest Dynatrace Managed MCP Server releases"/>
   </a>
   <a href="https://github.com/dynatrace-oss/dynatrace-managed-mcp/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/license-mit-blue.svg" alt="Dynatrace Managed MCP Server is released under the MIT License" />
+    <img src="https://img.shields.io/badge/License-Apache_2.0-blue?color=7c38a1" alt="Dynatrace Managed MCP Server is released under the Apache 2.0 License" />
   </a>
-  <a href="https://www.npmjs.com/package/@dynatrace-oss/dynatrace-managed-mcp">
-    <img src="https://img.shields.io/npm/dm/@dynatrace-oss/dynatrace-managed-mcp?logo=npm&style=flat&color=red" alt="npm" />
+  <a href="https://www.npmjs.com/package/@dynatrace-oss/dynatrace-managed-mcp-server">
+    <img src="https://img.shields.io/npm/dm/@dynatrace-oss/dynatrace-managed-mcp-server?logo=npm&color=5ead35" alt="npm" />
+  </a>
+  <a href="https://github.com/dynatrace-oss/dynatrace-managed-mcp">
+    <img src="https://img.shields.io/github/contributors/dynatrace-oss/dynatrace-managed-mcp?color=5ead35" alt="Dynatrace Managed MCP Server Contributors on GitHub" />
   </a>
   <a href="https://github.com/dynatrace-oss/dynatrace-managed-mcp">
     <img src="https://img.shields.io/github/stars/dynatrace-oss/dynatrace-managed-mcp" alt="Dynatrace Managed MCP Server Stars on GitHub" />
-  </a>
-  <a href="https://github.com/dynatrace-oss/dynatrace-managed-mcp">
-    <img src="https://img.shields.io/github/contributors/dynatrace-oss/dynatrace-managed-mcp?color=green" alt="Dynatrace Managed MCP Server Contributors on GitHub" />
   </a>
 </h4>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3870,9 +3870,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1"
+      },
+      "engines": {
+        "node": ">=26.5.1 <27"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dynatrace-oss/dynatrace-managed-mcp-server",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=26.5.1 <27"
+  },
   "mcpName": "io.github.dynatrace-oss/dynatrace-managed-mcp",
   "description": "Model Context Protocol (MCP) server for Dynatrace Managed (self-hosted)",
   "keywords": [


### PR DESCRIPTION
- bump node version in Dockerfile
- add engine property to point to min and max versions of node