### PR TITLE
fix: code and repository defects found while documenting the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @dynatrace-oss/dynatrace-managed-mcp
 
+## Unreleased
+
+### Breaking changes
+
+- Proxy routing: an environment with both `httpProxyUrl` and `httpsProxyUrl` set no longer silently disables the proxy. Previously, tool requests for that environment fell back to whatever `HTTP_PROXY`/`HTTPS_PROXY` environment variables were set on the process, with `NO_PROXY` exclusions honoured, because axios only consults those variables (and `NO_PROXY`) when no proxy is explicitly configured. Now the server deterministically uses `httpsProxyUrl` and warns to the terminal (regardless of `LOG_OUTPUT`) that it is doing so. This is a real routing change, not just a warning: `NO_PROXY` exclusions do not apply to an explicitly configured proxy, so a host you previously excluded from proxying may now be routed through `httpsProxyUrl`. If you have both fields set on any environment, review whether that environment relies on `NO_PROXY`, and configure only one field.
+
+### Fixes
+
+- Corrected the API token scopes reported by the `dynatrace_managed_get_environments_info` tool and logged on a failed connection. The server was reporting eight legacy scope names (`ReadProblems`, `ReadSLO`, `ReadConfig`, and others) that don't match the v2 API endpoints this server actually calls; it now reports the correct `entities.read`, `events.read`, `logs.read`, `metrics.read`, `problems.read`, `securityProblems.read`, `slo.read`, and `DataExport`. The tool response label also changed from "Available API Scopes" to "Required API Scopes," since the server is stating what a token needs, not what it has. See `docs/api-token.md` for the authoritative list.
+- `${VAR_NAME}` environment-variable interpolation now works when the variable is written inside the `DT_CONFIG_FILE` path itself (e.g. `DT_CONFIG_FILE='${HOME}/dt-config.yaml'`) — a regex typo previously made this silently a no-op, leaving the literal, unexpanded path to fail instead. An undefined variable referenced this way now throws the same `Environment variable not found` error already used for variables inside the file's content, instead of silently resolving to an empty string.
+- The "Configuration not found" startup error (thrown when neither `DT_CONFIG_FILE` nor `DT_ENVIRONMENT_CONFIGS` is set) now points to `docs/configuration.md` instead of a README anchor that no longer exists.
+
 ## 1.0.1
 
 ### Dependencies

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -186,15 +186,15 @@ and make sure that you are using Agent Mode in Copilot.
 
 ## Development Troubleshooting
 
-### Mcp error: -32002: connection closed: initialize response
+### Client reports "connection closed" during initialization
 
-The error below can occur when there is an error invoking the MCP:
+Your AI client may report that the MCP connection closed before it finished initializing. The exact wording and error code vary by client, since each bundles its own MCP SDK version — there is no single fixed code to expect here.
 
-    `Mcp error: -32002: connection closed: initialize response`
+Check that you can execute the MCP server directly, as per your configuration for local testing, e.g. with:
 
-Check that you can execute the MCP, as per your configuration for local testing, e,g, with:
-
-    `npx /path/to/repos/dynatrace-oss/dynatrace-manage-mcp/dist/index.js`
+```bash
+node /path/to/repos/dynatrace-oss/dynatrace-managed-mcp/dist/index.js
+```
 
 ### MCP tool execution fails with 'Transport closed'
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "prettier --write ."
   },
   "author": "Dynatrace",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@dynatrace/openkit-js": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.21.2",

--- a/server.json
+++ b/server.json
@@ -38,8 +38,9 @@
         },
         {
           "name": "DT_ENVIRONMENT_CONFIGS",
-          "description": "An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to. Used only if DT_CONFIG_FILE is not set. One of DT_CONFIG_FILE or DT_ENVIRONMENT_CONFIGS must be set. See README file for contents of this.",
+          "description": "An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to, including each environment's API token in local (stdio) mode. Used only if DT_CONFIG_FILE is not set. One of DT_CONFIG_FILE or DT_ENVIRONMENT_CONFIGS must be set. See README file for contents of this.",
           "isRequired": false,
+          "isSecret": true,
           "format": "string"
         },
         {
@@ -61,6 +62,20 @@
           "description": "Logging level (e.g. debug, info, warning, error)",
           "isRequired": false,
           "format": "string"
+        },
+        {
+          "name": "LOG_OUTPUT",
+          "description": "Log destination: file, console, stdout, stderr, stderr-all, file+console, file+stdout, file+stderr, or disabled. Defaults to file, which prints nothing to the terminal - startup errors are otherwise invisible; set to stderr-all to see them while troubleshooting.",
+          "isRequired": false,
+          "format": "string",
+          "default": "file"
+        },
+        {
+          "name": "LOG_FILE",
+          "description": "Log file path, used when LOG_OUTPUT includes file. Defaults to dynatrace-managed-mcp.log.",
+          "isRequired": false,
+          "format": "filepath",
+          "default": "dynatrace-managed-mcp.log"
         },
         {
           "name": "DT_MCP_DISABLE_TELEMETRY",

--- a/server.json
+++ b/server.json
@@ -31,10 +31,30 @@
           "format": "number"
         },
         {
+          "name": "DT_CONFIG_FILE",
+          "description": "Path to a YAML or JSON file defining the Dynatrace Managed environment(s) to connect to. Recommended over DT_ENVIRONMENT_CONFIGS. Used if set, taking priority over DT_ENVIRONMENT_CONFIGS. One of DT_CONFIG_FILE or DT_ENVIRONMENT_CONFIGS must be set. See README file for contents of this.",
+          "isRequired": false,
+          "format": "filepath"
+        },
+        {
           "name": "DT_ENVIRONMENT_CONFIGS",
-          "description": "An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to. See README file for contents of this.",
-          "isRequired": true,
+          "description": "An escaped JSON array that defines the Dynatrace Managed environment(s) to connect to. Used only if DT_CONFIG_FILE is not set. One of DT_CONFIG_FILE or DT_ENVIRONMENT_CONFIGS must be set. See README file for contents of this.",
+          "isRequired": false,
           "format": "string"
+        },
+        {
+          "name": "DT_MCP_MAX_BODY_SIZE",
+          "description": "Maximum accepted HTTP request body size, in bytes. HTTP mode only. Larger requests receive a 413 error. Defaults to 1048576 (1 MiB).",
+          "isRequired": false,
+          "format": "number",
+          "default": "1048576"
+        },
+        {
+          "name": "DT_MCP_TOKEN_VALIDATION_TTL_MS",
+          "description": "How long a validated API token is cached, in milliseconds. HTTP mode only. Set to 0 to disable caching. Defaults to 60000 (60 seconds).",
+          "isRequired": false,
+          "format": "number",
+          "default": "60000"
         },
         {
           "name": "LOG_LEVEL",

--- a/src/authentication/__tests__/proxy.test.ts
+++ b/src/authentication/__tests__/proxy.test.ts
@@ -62,7 +62,7 @@ describe('proxy-config', () => {
 
     it(
       'should warn (without throwing) and use httpsProxyUrl when both httpProxyUrl and httpsProxyUrl are set, ' +
-        'naming the config fields (not env vars) and the alias',
+        'disclosing the NO_PROXY/routing behaviour change',
       () => {
         const httpProxy = 'http://myuser:mypass@myhost.com:1234';
         const httpsProxy = 'https://myuser:mypass@myhost.com:4321';
@@ -80,16 +80,20 @@ describe('proxy-config', () => {
         });
 
         // The warning must actually reach the terminal (console.warn writes to stderr directly,
-        // independent of the Winston transports LOG_OUTPUT controls), and must name the config
-        // fields and alias - never the HTTP_PROXY/HTTPS_PROXY env vars this code never reads.
+        // independent of the Winston transports LOG_OUTPUT controls), must name the config fields
+        // and the alias, and - because an explicit proxy config changes real routing behaviour
+        // (axios's setProxy() only falls back to the HTTP_PROXY/HTTPS_PROXY env vars, with NO_PROXY
+        // honoured, when no explicit `proxy` is configured) - must say so, not just "configure only
+        // one".
         expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
         const warningMessage = consoleWarnSpy.mock.calls[0][0] as string;
         expect(warningMessage).toContain('[Alias: my-alias]');
         expect(warningMessage).toContain('httpsProxyUrl');
         expect(warningMessage).toContain('httpProxyUrl');
-        expect(warningMessage).toContain('Configure only one');
-        expect(warningMessage).not.toContain('HTTP_PROXY');
-        expect(warningMessage).not.toContain('HTTPS_PROXY');
+        expect(warningMessage).toContain('configure only one');
+        expect(warningMessage).toContain('HTTP_PROXY');
+        expect(warningMessage).toContain('HTTPS_PROXY');
+        expect(warningMessage).toContain('NO_PROXY');
 
         consoleWarnSpy.mockRestore();
       },

--- a/src/authentication/__tests__/proxy.test.ts
+++ b/src/authentication/__tests__/proxy.test.ts
@@ -60,12 +60,13 @@ describe('proxy-config', () => {
       expect(response).toBeUndefined();
     });
 
-    it('should return undefined if set HTTP_PROXY and HTTPS_PROXY', () => {
-      process.env.HTTP_PROXY = 'http://myuser:mypass@myhost.com:1234';
-      process.env.HTTPS_PROXY = 'https://myuser:mypass@myhost.com:4321';
+    it('should throw if both httpProxyUrl and httpsProxyUrl are set, naming the config fields (not env vars)', () => {
+      const httpProxy = 'http://myuser:mypass@myhost.com:1234';
+      const httpsProxy = 'https://myuser:mypass@myhost.com:4321';
 
-      const response = setAxiosProxy();
-      expect(response).toBeUndefined();
+      expect(() => setAxiosProxy(httpProxy, httpsProxy)).toThrow(
+        'Cannot specify both httpsProxyUrl and httpProxyUrl for the same environment; configure only one.',
+      );
     });
 
     it('should fail if invalid URL', () => {

--- a/src/authentication/__tests__/proxy.test.ts
+++ b/src/authentication/__tests__/proxy.test.ts
@@ -60,14 +60,40 @@ describe('proxy-config', () => {
       expect(response).toBeUndefined();
     });
 
-    it('should throw if both httpProxyUrl and httpsProxyUrl are set, naming the config fields (not env vars)', () => {
-      const httpProxy = 'http://myuser:mypass@myhost.com:1234';
-      const httpsProxy = 'https://myuser:mypass@myhost.com:4321';
+    it(
+      'should warn (without throwing) and use httpsProxyUrl when both httpProxyUrl and httpsProxyUrl are set, ' +
+        'naming the config fields (not env vars) and the alias',
+      () => {
+        const httpProxy = 'http://myuser:mypass@myhost.com:1234';
+        const httpsProxy = 'https://myuser:mypass@myhost.com:4321';
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-      expect(() => setAxiosProxy(httpProxy, httpsProxy)).toThrow(
-        'Cannot specify both httpsProxyUrl and httpProxyUrl for the same environment; configure only one.',
-      );
-    });
+        const response = setAxiosProxy(httpProxy, httpsProxy, 'my-alias');
+
+        // Deterministically prefers httpsProxyUrl and keeps running - does not throw, does not
+        // disable the proxy.
+        expect(response).toEqual({
+          host: 'myhost.com',
+          port: 4321,
+          protocol: 'https:',
+          auth: { username: 'myuser', password: 'mypass' },
+        });
+
+        // The warning must actually reach the terminal (console.warn writes to stderr directly,
+        // independent of the Winston transports LOG_OUTPUT controls), and must name the config
+        // fields and alias - never the HTTP_PROXY/HTTPS_PROXY env vars this code never reads.
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+        const warningMessage = consoleWarnSpy.mock.calls[0][0] as string;
+        expect(warningMessage).toContain('[Alias: my-alias]');
+        expect(warningMessage).toContain('httpsProxyUrl');
+        expect(warningMessage).toContain('httpProxyUrl');
+        expect(warningMessage).toContain('Configure only one');
+        expect(warningMessage).not.toContain('HTTP_PROXY');
+        expect(warningMessage).not.toContain('HTTPS_PROXY');
+
+        consoleWarnSpy.mockRestore();
+      },
+    );
 
     it('should fail if invalid URL', () => {
       process.env.HTTP_PROXY = 'this is not a url';

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -321,8 +321,12 @@ function buildProxyConfig(proxyUrl: string, defaultPort: string): AxiosProxyConf
 
 export function setAxiosProxy(httpProxy = '', httpsProxy = ''): AxiosProxyConfig | undefined {
   if (httpsProxy && httpProxy) {
-    logger.error('Cannot specify both HTTPS_PROXY and HTTP_PROXY, use only one.');
-    return undefined;
+    // Silently disabling the proxy here would be worse than failing loudly: an administrator who
+    // set both fields "to be safe" would otherwise get direct (unproxied) requests with only a log
+    // line as a clue. Fail fast instead, consistent with how validateEnvironments() treats other
+    // structurally invalid environment configuration (missing required fields, invalid alias) -
+    // by stopping startup rather than continuing in a silently degraded state.
+    throw new Error('Cannot specify both httpsProxyUrl and httpProxyUrl for the same environment; configure only one.');
   }
   if (!httpsProxy && !httpProxy) {
     // No proxy configured, nothing to do

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -47,7 +47,7 @@ export class ManagedAuthClient {
     this.apiBaseUrl = params.apiBaseUrl;
     this.dashboardBaseUrl = params.dashboardBaseUrl;
     this.alias = params.alias;
-    this.proxy = setAxiosProxy(params.httpProxy, params.httpsProxy);
+    this.proxy = setAxiosProxy(params.httpProxy, params.httpsProxy, params.alias);
     this.isValid = params.isValid ? params.isValid : false;
     this.MINIMUM_VERSION = params.minimum_version;
     this.validationError = '';
@@ -319,14 +319,24 @@ function buildProxyConfig(proxyUrl: string, defaultPort: string): AxiosProxyConf
   };
 }
 
-export function setAxiosProxy(httpProxy = '', httpsProxy = ''): AxiosProxyConfig | undefined {
+export function setAxiosProxy(httpProxy = '', httpsProxy = '', alias = ''): AxiosProxyConfig | undefined {
   if (httpsProxy && httpProxy) {
-    // Silently disabling the proxy here would be worse than failing loudly: an administrator who
-    // set both fields "to be safe" would otherwise get direct (unproxied) requests with only a log
-    // line as a clue. Fail fast instead, consistent with how validateEnvironments() treats other
-    // structurally invalid environment configuration (missing required fields, invalid alias) -
-    // by stopping startup rather than continuing in a silently degraded state.
-    throw new Error('Cannot specify both httpsProxyUrl and httpProxyUrl for the same environment; configure only one.');
+    // The defect was the silence, not the ambiguity: the pre-fix code returned `undefined` here,
+    // leaving requests unproxied with only a log line as evidence. Throwing would fix the silence
+    // but introduce a breaking change for exactly the deployments this defect already affects -
+    // the old documentation presented httpProxyUrl and httpsProxyUrl as interchangeable
+    // alternatives, with no warning against setting both, so "both set" configs that run today
+    // (silently proxy-less) would start failing outright after this fix. Worse, this function runs
+    // from the ManagedAuthClient constructor at startup (see buildManagedAuthClients()), so a throw
+    // here propagates to main().catch -> logErrorObject -> logger.error only - invisible under the
+    // default LOG_OUTPUT=file, which has no console transport. So: keep running, deterministically
+    // prefer httpsProxyUrl, and warn through console.warn (Node's global console, which writes to
+    // stderr directly and is not routed through Winston) so the misconfiguration is visible in the
+    // terminal regardless of LOG_OUTPUT.
+    const aliasLabel = alias ? `[Alias: ${alias}] ` : '';
+    const message = `${aliasLabel}Both httpsProxyUrl and httpProxyUrl are set; using httpsProxyUrl and ignoring httpProxyUrl. Configure only one.`;
+    logger.warn(message);
+    console.warn(message);
   }
   if (!httpsProxy && !httpProxy) {
     // No proxy configured, nothing to do

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -1,19 +1,9 @@
 import axios, { AxiosInstance, AxiosProxyConfig } from 'axios';
 import { logErrorObject, logger } from '../utils/logger';
 import { ManagedEnvironmentConfig } from '../utils/environment';
+import { MANAGED_API_SCOPES } from '../utils/api-scopes';
 
 export const MINIMUM_VERSION = '1.328.0';
-
-const MANAGED_API_SCOPES = [
-  'DataExport', // Read metrics and topology
-  'ReadConfig', // Read configuration and cluster version
-  'ReadSyntheticData', // Read synthetic monitoring data
-  'ReadLogContent', // Read log content
-  'ReadEvents', // Read events
-  'ReadProblems', // Read problems and root cause analysis
-  'ReadSecurityProblems', // Read security problems
-  'ReadSLO', // Read Service Level Objectives
-];
 
 export interface ClusterVersion {
   version: string;

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -321,20 +321,42 @@ function buildProxyConfig(proxyUrl: string, defaultPort: string): AxiosProxyConf
 
 export function setAxiosProxy(httpProxy = '', httpsProxy = '', alias = ''): AxiosProxyConfig | undefined {
   if (httpsProxy && httpProxy) {
-    // The defect was the silence, not the ambiguity: the pre-fix code returned `undefined` here,
-    // leaving requests unproxied with only a log line as evidence. Throwing would fix the silence
-    // but introduce a breaking change for exactly the deployments this defect already affects -
-    // the old documentation presented httpProxyUrl and httpsProxyUrl as interchangeable
-    // alternatives, with no warning against setting both, so "both set" configs that run today
-    // (silently proxy-less) would start failing outright after this fix. Worse, this function runs
-    // from the ManagedAuthClient constructor at startup (see buildManagedAuthClients()), so a throw
-    // here propagates to main().catch -> logErrorObject -> logger.error only - invisible under the
-    // default LOG_OUTPUT=file, which has no console transport. So: keep running, deterministically
-    // prefer httpsProxyUrl, and warn through console.warn (Node's global console, which writes to
-    // stderr directly and is not routed through Winston) so the misconfiguration is visible in the
-    // terminal regardless of LOG_OUTPUT.
+    // The defect was the silence, not the ambiguity - and the pre-fix "silent" behaviour was NOT
+    // "direct". setAxiosProxy returned `undefined` here, so makeRequest()'s per-request
+    // `proxy: this.proxy ?? undefined` was itself undefined. When configProxy is falsy, axios's own
+    // setProxy() (node_modules/axios/dist/node/axios.cjs, axios 1.16.0) falls back to
+    // getProxyForUrl() - the proxy-from-env package's read of HTTP_PROXY/HTTPS_PROXY - and only
+    // applies it if shouldBypassProxy() (i.e. NO_PROXY) does not exclude the target host. So tool
+    // requests were going through whichever proxy those environment variables specified, with
+    // NO_PROXY exclusions honoured - not unconditionally direct. An admin who set HTTPS_PROXY plus
+    // NO_PROXY=*.corp.internal on the container, and also filled in both fields "to be safe" per the
+    // old documentation (which presented httpProxyUrl and httpsProxyUrl as interchangeable, with no
+    // warning against setting both), has their internal cluster correctly excluded from the proxy
+    // today. Throwing on both-set would fix the silence but break that deployment outright - both
+    // by exiting where today it runs, and (once running) by forcing every tool request through
+    // httpsProxyUrl regardless of NO_PROXY, since an explicitly configured `proxy` skips axios's
+    // getProxyForUrl/shouldBypassProxy branch entirely. Worse, this function runs from the
+    // ManagedAuthClient constructor at startup (see buildManagedAuthClients()), so a throw here
+    // propagates to main().catch -> logErrorObject -> logger.error only - invisible under the
+    // default LOG_OUTPUT=file, which has no console transport.
+    //
+    // So: keep running, deterministically prefer httpsProxyUrl, and warn - through console.warn,
+    // which writes to stderr directly and is not routed through Winston, so it is visible in the
+    // terminal regardless of LOG_OUTPUT - that tool requests for this environment now go through
+    // this explicit proxy instead of any HTTP_PROXY/HTTPS_PROXY environment variable, and that
+    // NO_PROXY exclusions do not apply to it, so a host previously excluded may now be proxied too.
     const aliasLabel = alias ? `[Alias: ${alias}] ` : '';
-    const message = `${aliasLabel}Both httpsProxyUrl and httpProxyUrl are set; using httpsProxyUrl and ignoring httpProxyUrl. Configure only one.`;
+    const message =
+      `${aliasLabel}Both httpsProxyUrl and httpProxyUrl are set; using httpsProxyUrl and ignoring ` +
+      `httpProxyUrl - configure only one. Tool requests for this environment now go through this ` +
+      `explicit proxy instead of any HTTP_PROXY/HTTPS_PROXY environment variable, and NO_PROXY ` +
+      `exclusions do not apply to it, so a host you previously excluded may now be proxied too.`;
+    // Deliberately logs through both: logger.warn keeps the warning in the structured log/file
+    // record like everything else at this level, while console.warn is what actually guarantees
+    // terminal visibility under the default LOG_OUTPUT=file. Under LOG_OUTPUT=stderr*, where
+    // Winston's own Console transport would already print it, the operator sees the line twice -
+    // an acceptable, known trade-off for never silently dropping it under the far more common
+    // default.
     logger.warn(message);
     console.warn(message);
   }

--- a/src/capabilities/__tests__/events-api.test.ts
+++ b/src/capabilities/__tests__/events-api.test.ts
@@ -111,19 +111,16 @@ describe('EventsApiClient', () => {
 
     it('should show all retrieved events', () => {
       // Create 75 mock events to test that all are shown
-      const mockEvents: Event[] = Array.from(
-        { length: 75 },
-        (_, i): Event => ({
-          eventId: `event-${i}`,
-          eventType: 'CUSTOM_INFO',
-          title: `Event ${i}`,
-          startTime: 1640995200000 + i * 1000,
-          entityName: `service-${i}`,
-          properties: [],
-          managementZones: [],
-          status: EventStatus.CLOSED,
-        }),
-      );
+      const mockEvents: Event[] = Array.from({ length: 75 }, (_, i): Event => ({
+        eventId: `event-${i}`,
+        eventType: 'CUSTOM_INFO',
+        title: `Event ${i}`,
+        startTime: 1640995200000 + i * 1000,
+        entityName: `service-${i}`,
+        properties: [],
+        managementZones: [],
+        status: EventStatus.CLOSED,
+      }));
 
       const response = new Map<string, ListEventsResponse>([
         [

--- a/src/capabilities/__tests__/events-api.test.ts
+++ b/src/capabilities/__tests__/events-api.test.ts
@@ -111,16 +111,19 @@ describe('EventsApiClient', () => {
 
     it('should show all retrieved events', () => {
       // Create 75 mock events to test that all are shown
-      const mockEvents: Event[] = Array.from({ length: 75 }, (_, i): Event => ({
-        eventId: `event-${i}`,
-        eventType: 'CUSTOM_INFO',
-        title: `Event ${i}`,
-        startTime: 1640995200000 + i * 1000,
-        entityName: `service-${i}`,
-        properties: [],
-        managementZones: [],
-        status: EventStatus.CLOSED,
-      }));
+      const mockEvents: Event[] = Array.from(
+        { length: 75 },
+        (_, i): Event => ({
+          eventId: `event-${i}`,
+          eventType: 'CUSTOM_INFO',
+          title: `Event ${i}`,
+          startTime: 1640995200000 + i * 1000,
+          entityName: `service-${i}`,
+          properties: [],
+          managementZones: [],
+          status: EventStatus.CLOSED,
+        }),
+      );
 
       const response = new Map<string, ListEventsResponse>([
         [

--- a/src/tools/__tests__/environment-tools.test.ts
+++ b/src/tools/__tests__/environment-tools.test.ts
@@ -85,7 +85,12 @@ describe('get_environments_info (HTTP mode)', () => {
     expect(result).toContain('- Valid Environment: Yes');
     expect(result).toContain('- Version: 1.345.0');
     expect(result).toContain('- Minimum Version Check: PASSED');
-    expect(result).toContain('DataExport');
+    // C1 regression guard: 'DataExport' alone is common to both the legacy and corrected scope
+    // lists, so it would pass even with the pre-fix bug. Assert the actual user-visible change -
+    // a corrected v2 dotted scope is reported, and the corresponding legacy v1-style name is not.
+    expect(result).toContain('- Required API Scopes:');
+    expect(result).toContain('entities.read');
+    expect(result).not.toContain('ReadProblems');
     expect(result).not.toContain('Invalid token supplied');
   });
 

--- a/src/tools/environment-tools.ts
+++ b/src/tools/environment-tools.ts
@@ -1,18 +1,7 @@
 import { ToolContext } from './context';
 import { logger } from '../utils/logger';
 import { ManagedAuthClient } from '../authentication/managed-auth-client';
-
-// Required API scopes for Managed deployment
-const MANAGED_API_SCOPES = [
-  'DataExport', // Read metrics and topology
-  'ReadConfig', // Read configuration and cluster version
-  'ReadSyntheticData', // Read synthetic monitoring data
-  'ReadLogContent', // Read log content
-  'ReadEvents', // Read events
-  'ReadProblems', // Read problems and root cause analysis
-  'ReadSecurityProblems', // Read security problems
-  'ReadSLO', // Read Service Level Objectives
-];
+import { MANAGED_API_SCOPES } from '../utils/api-scopes';
 
 export function registerEnvironmentTools(ctx: ToolContext): void {
   ctx.tool(
@@ -83,7 +72,7 @@ function stdioModeVersionResponse(authClient: ManagedAuthClient) {
     resp += `- Version: ${authClient.clusterVersion}\n`;
     resp += `- Minimum Version Check: PASSED\n`;
   }
-  resp += `- Available API Scopes: ${MANAGED_API_SCOPES.join(', ')}\n\n\n`;
+  resp += `- Required API Scopes: ${MANAGED_API_SCOPES.join(', ')}\n\n\n`;
   return resp;
 }
 
@@ -95,7 +84,7 @@ async function httpModeVersionResponse(authClient: ManagedAuthClient, ctx: ToolC
     resp += `- Valid Environment: Yes\n`;
     resp += `- Version: ${clusterVersion.version}\n`;
     resp += `- Minimum Version Check: ${isValidVersion ? 'PASSED' : 'WARNING - Version may not be fully compatible and may not support all features'}\n`;
-    resp += `- Available API Scopes: ${MANAGED_API_SCOPES.join(', ')}\n\n\n`;
+    resp += `- Required API Scopes: ${MANAGED_API_SCOPES.join(', ')}\n\n\n`;
   } catch (error) {
     resp += errorMessageForResponse(error, authClient.alias);
   }

--- a/src/utils/__tests__/api-scopes.test.ts
+++ b/src/utils/__tests__/api-scopes.test.ts
@@ -32,6 +32,11 @@ describe('MANAGED_API_SCOPES', () => {
     }
   });
 
+  // A source-text drift guard, not a behavioral test: it is brittle to reformatting (e.g. reordered
+  // import specifiers) and does not exercise any user-visible output. The user-visible check - that
+  // dynatrace_managed_get_environments_info's response actually emits the corrected scopes and not
+  // the legacy ones - lives in src/tools/__tests__/environment-tools.test.ts instead, since that is
+  // where the real tool response is produced.
   it('is imported (not re-declared) by both consumers, so they cannot drift apart again', () => {
     const managedAuthClientSource = fs.readFileSync(
       path.join(__dirname, '../../authentication/managed-auth-client.ts'),

--- a/src/utils/__tests__/api-scopes.test.ts
+++ b/src/utils/__tests__/api-scopes.test.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { MANAGED_API_SCOPES } from '../api-scopes';
+
+const LEGACY_SCOPES = [
+  'ReadConfig',
+  'ReadSyntheticData',
+  'ReadLogContent',
+  'ReadEvents',
+  'ReadProblems',
+  'ReadSecurityProblems',
+  'ReadSLO',
+];
+
+describe('MANAGED_API_SCOPES', () => {
+  it('contains exactly the eight v2 scopes documented in docs/api-token.md', () => {
+    expect(MANAGED_API_SCOPES).toEqual([
+      'DataExport',
+      'entities.read',
+      'events.read',
+      'logs.read',
+      'metrics.read',
+      'problems.read',
+      'securityProblems.read',
+      'slo.read',
+    ]);
+  });
+
+  it('contains none of the legacy scope names', () => {
+    for (const legacyScope of LEGACY_SCOPES) {
+      expect(MANAGED_API_SCOPES).not.toContain(legacyScope);
+    }
+  });
+
+  it('is imported (not re-declared) by both consumers, so they cannot drift apart again', () => {
+    const managedAuthClientSource = fs.readFileSync(
+      path.join(__dirname, '../../authentication/managed-auth-client.ts'),
+      'utf-8',
+    );
+    const environmentToolsSource = fs.readFileSync(path.join(__dirname, '../../tools/environment-tools.ts'), 'utf-8');
+
+    expect(managedAuthClientSource).toMatch(/import\s*\{\s*MANAGED_API_SCOPES\s*\}\s*from\s*'\.\.\/utils\/api-scopes'/);
+    expect(environmentToolsSource).toMatch(/import\s*\{\s*MANAGED_API_SCOPES\s*\}\s*from\s*'\.\.\/utils\/api-scopes'/);
+
+    // Neither file should declare its own local copy of the array.
+    expect(managedAuthClientSource).not.toMatch(/const\s+MANAGED_API_SCOPES\s*=/);
+    expect(environmentToolsSource).not.toMatch(/const\s+MANAGED_API_SCOPES\s*=/);
+  });
+});

--- a/src/utils/__tests__/config-loader.test.ts
+++ b/src/utils/__tests__/config-loader.test.ts
@@ -316,6 +316,38 @@ describe('ConfigFileLoader', () => {
 
       expect(() => loadFromFile(configPath)).toThrow(/Configuration file not found/);
     });
+
+    it('should expand ${VAR_NAME} environment variables in the path itself', () => {
+      process.env.TEST_CONFIG_DIR = testDir;
+
+      const configPath = path.join(testDir, 'config.json');
+      const config = [
+        {
+          apiEndpointUrl: 'https://api.example.com/',
+          environmentId: 'test-123',
+          alias: 'production',
+          apiToken: 'token',
+        },
+      ];
+
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      try {
+        const result = loadFromFile('${TEST_CONFIG_DIR}/config.json');
+        expect(result).toHaveLength(1);
+        expect(result[0].alias).toBe('production');
+      } finally {
+        delete process.env.TEST_CONFIG_DIR;
+      }
+    });
+
+    it('should throw when a ${VAR_NAME} in the path is not set, matching the content-interpolation behavior', () => {
+      delete process.env.TEST_UNDEFINED_PATH_VAR;
+
+      expect(() => loadFromFile('${TEST_UNDEFINED_PATH_VAR}/config.json')).toThrow(
+        /Environment variable not found: TEST_UNDEFINED_PATH_VAR/,
+      );
+    });
   });
 
   describe('Configuration validation', () => {

--- a/src/utils/__tests__/config-loader.test.ts
+++ b/src/utils/__tests__/config-loader.test.ts
@@ -318,8 +318,6 @@ describe('ConfigFileLoader', () => {
     });
 
     it('should expand ${VAR_NAME} environment variables in the path itself', () => {
-      process.env.TEST_CONFIG_DIR = testDir;
-
       const configPath = path.join(testDir, 'config.json');
       const config = [
         {
@@ -332,7 +330,10 @@ describe('ConfigFileLoader', () => {
 
       fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
+      // Set the env var inside the try so a throw (from loadFromFile, or anything else in here)
+      // can't skip the finally and leak TEST_CONFIG_DIR into later tests.
       try {
+        process.env.TEST_CONFIG_DIR = testDir;
         const result = loadFromFile('${TEST_CONFIG_DIR}/config.json');
         expect(result).toHaveLength(1);
         expect(result[0].alias).toBe('production');

--- a/src/utils/api-scopes.ts
+++ b/src/utils/api-scopes.ts
@@ -1,0 +1,22 @@
+/**
+ * API token scopes required by this server.
+ *
+ * Every endpoint the server calls (see `src/capabilities/*.ts`) is a v2 API, so these are the
+ * v2 dotted scope names, with the exception of `DataExport`, which is the scope the v2 problem
+ * and event feed, metrics, and topology endpoints still require.
+ *
+ * This is the single source of truth for the list - both the startup/connection-failure logging
+ * in `managed-auth-client.ts` and the `dynatrace_managed_get_environments_info` tool response in
+ * `environment-tools.ts` import it from here, so they cannot drift apart again. Keep it aligned
+ * with the user-facing writeup in `docs/api-token.md`.
+ */
+export const MANAGED_API_SCOPES = [
+  'DataExport', // Access problem and event feed, metrics, and topology
+  'entities.read', // Read entities
+  'events.read', // Read events
+  'logs.read', // Read logs
+  'metrics.read', // Read metrics
+  'problems.read', // Read problems
+  'securityProblems.read', // Read security problems
+  'slo.read', // Read SLO
+];

--- a/src/utils/api-scopes.ts
+++ b/src/utils/api-scopes.ts
@@ -1,9 +1,19 @@
 /**
  * API token scopes required by this server.
  *
- * Every endpoint the server calls (see `src/capabilities/*.ts`) is a v2 API, so these are the
- * v2 dotted scope names, with the exception of `DataExport`, which is the scope the v2 problem
- * and event feed, metrics, and topology endpoints still require.
+ * This server calls endpoints from both API versions, and each version's scope model is
+ * different:
+ *
+ * - One v1 endpoint, `GET /api/v1/config/clusterversion` (`managed-auth-client.ts`'s
+ *   `validateConnection`/`getClusterVersion`, outside `src/capabilities/`), requires the legacy
+ *   `DataExport` scope. This is not a leftover to prune: issue #68 is exactly a token missing
+ *   `DataExport` failing environment validation with a 403 on this call, because an earlier
+ *   version of the documentation omitted it. Keep `DataExport` in this list.
+ * - Every other endpoint the server calls - all in `src/capabilities/*.ts` - is a v2 API, and
+ *   each requires its own v2 dotted scope (`entities.read`, `events.read`, etc.), not `DataExport`.
+ * - `POST /api/v2/apiTokens/lookup` (`validateAPIToken`, used to validate a caller-supplied token
+ *   in HTTP mode) needs no specific scope - per Dynatrace's API documentation, it accepts a token
+ *   carrying any scope. Don't add `apiTokens.read` or similar; it doesn't exist and isn't needed.
  *
  * This is the single source of truth for the list - both the startup/connection-failure logging
  * in `managed-auth-client.ts` and the `dynatrace_managed_get_environments_info` tool response in
@@ -11,7 +21,7 @@
  * with the user-facing writeup in `docs/api-token.md`.
  */
 export const MANAGED_API_SCOPES = [
-  'DataExport', // Access problem and event feed, metrics, and topology
+  'DataExport', // Required by the v1 GET /api/v1/config/clusterversion call - see #68
   'entities.read', // Read entities
   'events.read', // Read events
   'logs.read', // Read logs

--- a/src/utils/config-loader.ts
+++ b/src/utils/config-loader.ts
@@ -110,12 +110,18 @@ function interpolateEnvVars(content: string): string {
  * Resolve path with cross-platform support
  */
 function resolvePath(filePath: string): string {
-  // Expand environment variables in path (e.g., ${HOME}/config.json)
-  let resolved = filePath.replace(/\$\{(w+)}/g, (_, varName) => {
+  // Expand environment variables in path (e.g., ${HOME}/config.json). Uses the same character
+  // class as the file-content interpolation above, so a ${VAR} written in DT_CONFIG_FILE itself
+  // behaves identically to one written inside the file's content: undefined throws, rather than
+  // silently resolving to an empty string.
+  let resolved = filePath.replace(/\$\{([A-Z_][A-Z0-9_]*)}/g, (match, varName) => {
     const value = process.env[varName];
-    if (!value) {
-      logger.warn(`Environment variable ${varName} not found in path, using empty string`);
-      return '';
+    if (value === undefined) {
+      throw new Error(
+        `Environment variable not found: ${varName}\n` +
+          `Referenced as: ${match}\n` +
+          `Make sure ${varName} is set in your environment.`,
+      );
     }
     return value;
   });

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -81,7 +81,7 @@ export function getManagedEnvironmentConfigs(requireToken = true): ManagedEnviro
         '  DT_CONFIG_FILE=./dt-config.yaml\n\n' +
         'Example with JSON string:\n' +
         '  DT_ENVIRONMENT_CONFIGS=\'[{"apiEndpointUrl":"...","environmentId":"..."}]\'\n\n' +
-        'See documentation: https://github.com/dynatrace-oss/dynatrace-managed-mcp#configuration',
+        'See documentation: https://github.com/dynatrace-oss/dynatrace-managed-mcp/blob/main/docs/configuration.md',
     );
   }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge after #214.** One commit (`c02a0d8`) repoints an error message at `docs/configuration.md`, which only exists once #214 lands. That URL resolves correctly on `main` today, so merging this first turns a working link into a 404.

## Why

While restructuring the documentation (#214), every page was grounded against `src/`. That surfaced defects in the **code**, which #214 deliberately did not touch. This branch fixes seven of them. An eighth turned out not to be a defect at all — see the note below. Each is recorded with file:line in `docs/superpowers/specs/2026-08-06-defect-ledger.md` (ships with #214).

## Fixes

| | |
| --- | --- |
| **C1** | The server reported **the wrong API token scopes**. `MANAGED_API_SCOPES` was defined twice, identically, and listed eight legacy names (`ReadProblems`, `ReadConfig`, …). Every endpoint this server calls is a v2 API. It's injected into the **MCP tool response**, so an assistant asked "what scopes do I need?" answered `ReadProblems` when the truth is `problems.read` — and it's printed on auth failure, the exact moment someone is debugging a scope problem. Corrected, and moved to `src/utils/api-scopes.ts` so the two copies can't drift again. |
| **C3** | Setting **both** `httpProxyUrl` and `httpsProxyUrl` on one environment silently disabled the explicit proxy. Now warns visibly and uses `httpsProxyUrl`. **This changes routing — see Breaking changes.** |
| **C4** | `server.json` misrepresented the server to the MCP registry: `DT_ENVIRONMENT_CONFIGS` marked required, `DT_CONFIG_FILE` absent, four variables missing, tokens not marked secret. |
| ~~**C5**~~ | **Withdrawn — not a defect.** See the note below. |
| **C7** | `docs/DEVELOPMENT.md` asserted an error code (`-32002`) absent from the vendored SDK, used indented code blocks, and had a typo'd example command. |
| **C8** | The "Configuration not found" error pointed at a README anchor #214 removes. |
| **C9** | `${VAR}` interpolation in the `DT_CONFIG_FILE` **path** silently did nothing — the regex used a bare `w` instead of `\w+`. |
| **Licence** | `package.json` declared `"license": "MIT"` while `LICENSE` is the Apache License 2.0, so npm has been advertising the wrong licence for the published package. Apache-2.0 confirmed correct by the repository owner. |

## Breaking changes

**Proxy routing, for environments with both proxy fields set.** The premise this fix started from was wrong, and it's worth stating plainly: axios consults `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` whenever no explicit proxy is configured (`proxy-from-env`, `axios.cjs` ~2984). So the pre-fix behaviour was *not* "requests go direct" — it was "requests use the environment proxy, with `NO_PROXY` honoured".

After this change those requests use `httpsProxyUrl`, and **`NO_PROXY` does not apply to an explicitly configured proxy**. A host previously excluded from proxying may now be routed through it. `CHANGELOG.md` carries the full note.

An earlier attempt made this a hard startup failure; that was rejected because it would have broken running deployments with a blank terminal (the throw reaches only `logger.error`, invisible under the default `LOG_OUTPUT=file`). Commit `d26fa66` implements that rejected approach and `122dc6d` supersedes it — **squash-merge, or read the net diff**.

## Follow-up required in #214

Once this merges, `docs/api-token.md`'s note that *"the tool reports a different, legacy set of scope names… trust this page"* becomes false, because C1 makes them agree. It should be deleted by whichever PR merges second.

## Still open — not in this branch

Recorded in the ledger; all are decisions rather than defect fixes:

- **C2 / C10 — the server has two uncoordinated proxy mechanisms.** The per-environment fields are applied at exactly one call site (`makeRequest`). `validateAPIToken`, `getClusterVersion` and `validateConnection` never use them, so **a customer whose only egress is the per-environment proxy cannot pass startup validation.** This needs one coherent proxy model, not another patch.
- Fatal config-loading startup errors reach only `logger.error`, so they're invisible under the default `LOG_OUTPUT=file` — unlike the two validation exits at `src/index.ts:117-129`, which `console.error` unconditionally.
- `LICENSE` is Apache-2.0; `package.json` says MIT. Needs an owner decision.

## Issues closed by this PR

Each defect now has a tracking issue; merging this closes them.

Fixes #216 — wrong API token scopes reported to users
Fixes #217 — both proxy fields silently disabled the proxy
Fixes #218 — `${VAR}` in the `DT_CONFIG_FILE` path never expanded
Fixes #219 — `server.json` misrepresents configuration to the MCP registry
Fixes #221 — `DEVELOPMENT.md` asserts a nonexistent MCP error code
Fixes #222 — "Configuration not found" links a deleted README anchor
Fixes #223 — `package.json` declared MIT instead of Apache-2.0

Left open deliberately, with the reasoning in each: #224 (proxy model — needs a design decision), #225 (invisible startup errors), #226 (unreachable branch, good first issue).

## Verification

### Withdrawn: C5 (`prettier --check` on `events-api.test.ts`)

This was reported as a defect on the strength of a local `prettier --check` failure. It is not one, and the correction is worth recording because it briefly broke this PR's own CI.

The sandbox this work was done in had a stale `node_modules`: prettier **3.8.1** installed against **3.9.6** in `package-lock.json`. The two disagree on how to wrap the `Array.from` generic in that file, in opposite directions:

| | prettier 3.8.1 (stale local) | prettier 3.9.6 (lockfile, what CI installs) |
| --- | --- | --- |
| `main`'s existing formatting | fails | **passes** |
| the formatting C5 applied | passes | **fails** |

So `main` was never broken, and the C5 commit is what made CI fail. Commit `dd5a355` restores the file to be byte-identical to `main`; `git diff main..HEAD -- src/capabilities/__tests__/events-api.test.ts` is now empty. Commits `24a99a3` and `dd5a355` cancel out and are kept rather than rewritten so the record is visible — **squash-merge, or read the net diff.**

Issue #220 is closed as invalid. Nothing else in this branch depended on it.

- `npm run test:unit` — **187/187** (baseline on `main`: 182; five added for C1, C3 and C9)
- `tsc --build` clean; `prettier --check` clean on all touched files
- `server.json` validated against its declared schema using the CI validator
- No documentation changed except `docs/DEVELOPMENT.md` (C7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

