### PR TITLE
NOISSUE(docs): document the token guard in validateManagedClients

### DIFF
--- a/src/authentication/__tests__/managed-auth-client.test.ts
+++ b/src/authentication/__tests__/managed-auth-client.test.ts
@@ -309,4 +309,20 @@ describe('validateManagedClients', () => {
     expect(validClients).toEqual([]);
     expect(validAliases).toEqual(['ALL_ENVIRONMENTS']);
   });
+
+  it('skips only the untokenized clients of a partial token map', async () => {
+    // buildConfigTokenMap omits environments without an apiToken, so the map may cover
+    // a subset of the clients; the tokenized ones must still be validated.
+    const tokenized = fakeAuthClient('prod', true);
+    const untokenized = fakeAuthClient('staging', true);
+    const { validClients, validAliases } = await validateManagedClients(
+      [tokenized, untokenized],
+      new Map([['prod', 't1']]),
+    );
+    expect(tokenized.isConfigured).toHaveBeenCalledWith('t1');
+    expect(untokenized.isConfigured).not.toHaveBeenCalled();
+    expect(untokenized.isValid).toBe(false);
+    expect(validClients).toEqual([tokenized]);
+    expect(validAliases).toEqual(['ALL_ENVIRONMENTS', 'prod']);
+  });
 });

--- a/src/authentication/managed-auth-client.ts
+++ b/src/authentication/managed-auth-client.ts
@@ -232,7 +232,15 @@ export function buildManagedAuthClients(configs: ManagedEnvironmentConfig[]): Ma
   );
 }
 
-/** stdio startup validation using config-provided tokens. Returns the reachable subset. */
+/**
+ * stdio startup validation using config-provided tokens. Returns the reachable subset.
+ *
+ * `tokens` is not guaranteed to hold an entry per client: `buildConfigTokenMap` only maps
+ * environments that carry an `apiToken`. The server's own stdio path loads its configuration with
+ * `requireToken=true`, so a missing token is already rejected before this runs - but this function
+ * is exported and does not own that precondition, so an alias with no token is skipped rather than
+ * validated with `undefined`.
+ */
 export async function validateManagedClients(
   clients: ManagedAuthClient[],
   tokens: Map<string, string>,
@@ -242,6 +250,7 @@ export async function validateManagedClients(
   for (const client of clients) {
     const token = tokens.get(client.alias);
     if (!token) {
+      // defensive: unreachable via the server's stdio startup, which requires a token per environment
       logger.warn(`[Alias: ${client.alias}] No token found; skipping startup validation`);
       continue;
     }


### PR DESCRIPTION
Closes #226.

The issue asked for one of two things: remove the token guard in `validateManagedClients`, or document why it is retained. This does the latter, because removing it would be a behaviour change the function does not get to make on its own.

### Why keep it

`validateManagedClients` is exported and takes `tokens` as a parameter — it does not own the precondition that every client has one. The map it receives comes from `buildConfigTokenMap`, which only maps environments that actually carry an `apiToken`:

```ts
for (const config of configs) {
  if (config.apiToken) {
    map.set(config.alias, config.apiToken);
  }
}
```

So a partial map is a shape the function can legitimately be handed. The issue is right that the server's own stdio path can't produce one today (`getManagedEnvironmentConfigs(!httpMode)` / `validateEnvironments(..., !httpMode)` reject a missing `apiToken` first), but that guarantee lives in `index.ts`, not here. Dropping the guard would turn that coupling into a silent `client.isConfigured(undefined as unknown as string)` the first time the two drift apart.

### Changes

- JSDoc on `validateManagedClients` explaining where the token map comes from and why an untokenized alias is skipped rather than validated with `undefined`.
- A one-line comment on the branch itself marking it as defensive, so the next reader doesn't take it for load-bearing — which is exactly what the issue asked for.
- A test for the partial-token-map case. The existing test passes an entirely empty map, so it never showed that the *tokenized* clients of a mixed set are still validated; the new one does, and pins the contract the comment describes.

No production behaviour change.

### Validation

```
npx jest src/                          15 suites, 183 tests passed
npx tsc --noEmit -p tsconfig.json      clean
npx eslint <both files>                clean
npx prettier --check <both files>      clean
```

---

*Assisted by Claude; reviewed and validated by me.*
