### PR TITLE
fix: surface fatal startup errors on stderr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { patchToolsListSchema } from './utils/mcp-compat';
 import { registerAllTools, ToolContext } from './tools';
 
 // Import logger after environment is loaded
-import { logger, flushLogger, logErrorObject } from './utils/logger';
+import { logger, flushLogger, logErrorObject, logFatalErrorObject } from './utils/logger';
 
 logger.info('Starting Dynatrace Managed MCP');
 
@@ -458,7 +458,7 @@ const main = async () => {
 };
 
 main().catch(async (error) => {
-  logErrorObject(error, 'Fatal error in main()');
+  logFatalErrorObject(error, 'Fatal error in main()');
   try {
     // report error in main
     const telemetry = await createAndInitializeTelemetry();

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,6 +1,6 @@
 import winston from 'winston';
 import axios, { AxiosError, AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { createLogger, sanitizeErrors } from '../logger';
+import { createLogger, logger, logFatalErrorObject, sanitizeErrors } from '../logger';
 import { TransformableInfo } from 'logform';
 
 function buildAxiosError(): AxiosError {
@@ -62,6 +62,80 @@ describe('sanitizeErrors', () => {
     ) as Record<string, unknown>;
 
     expect(info.data).toEqual({ rows: [1, 2, 3] });
+  });
+});
+
+describe('logFatalErrorObject', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('writes a safe single-line reason to stderr when logs go to a file', () => {
+    process.env.LOG_OUTPUT = 'file';
+    const loggerError = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const parserError = new Error(
+      'Failed to parse .yaml file: /tmp/config.yaml\n' +
+        'Error: bad indentation\n' +
+        'apiToken: dt0c01.SUPER_SECRET_VALUE',
+    );
+
+    logFatalErrorObject(parserError, 'Fatal error in main()');
+
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith('Fatal error in main(): Failed to parse .yaml file: /tmp/config.yaml');
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('SUPER_SECRET_VALUE');
+  });
+
+  it('retains a safe unsupported-format cause without exposing file content', () => {
+    process.env.LOG_OUTPUT = 'file';
+    jest.spyOn(logger, 'error').mockImplementation(() => logger);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const parserError = new Error('Failed to parse .toml file: /tmp/config.toml', {
+      cause: new Error('Unsupported file format: .toml\nfile content: SUPER_SECRET_VALUE'),
+    });
+
+    logFatalErrorObject(parserError, 'Fatal error in main()');
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Fatal error in main(): Failed to parse .toml file: /tmp/config.toml: Unsupported file format: .toml',
+    );
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('SUPER_SECRET_VALUE');
+  });
+
+  it.each(['stderr', 'stderr-all', 'file+stderr'])(
+    'does not duplicate the error when LOG_OUTPUT=%s already writes errors to stderr',
+    (logOutput) => {
+      process.env.LOG_OUTPUT = logOutput;
+      const loggerError = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+      logFatalErrorObject(new Error('Configuration not found'), 'Fatal error in main()');
+
+      expect(loggerError).toHaveBeenCalledWith('Fatal error in main(): Configuration not found');
+      expect(consoleError).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not expose Axios request metadata on stderr', () => {
+    process.env.LOG_OUTPUT = 'file';
+    jest.spyOn(logger, 'error').mockImplementation(() => logger);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    logFatalErrorObject(buildAxiosError(), 'Fatal error in main()');
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'ERR_BAD_REQUEST Fatal error in main(): Request failed with status code 401',
+    );
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('super-secret-value');
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('abc123');
   });
 });
 
@@ -192,6 +266,7 @@ describe('Logger Configuration', () => {
     const testLogger = createLogger();
 
     expect(testLogger.transports).toHaveLength(0);
+    expect(testLogger.silent).toBe(true);
   });
 
   it('should default to info log level', () => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -95,8 +95,10 @@ function createTransports(): winston.transport[] {
 }
 
 export function createLogger(): winston.Logger {
+  const logOutput = (process.env.LOG_OUTPUT || 'file').toLowerCase();
   return winston.createLogger({
     level: (process.env.LOG_LEVEL || 'info').toLowerCase(),
+    silent: logOutput === 'disabled',
     format: createFormat(),
     transports: createTransports(),
   });
@@ -104,16 +106,51 @@ export function createLogger(): winston.Logger {
 
 export const logger = createLogger();
 
-export function logErrorObject(error: unknown, message?: string) {
+function firstLine(details: string): string {
+  return details.split(/\r?\n/, 1)[0] ?? '';
+}
+
+function formatErrorDetails(error: Error, firstLineOnly: boolean): string {
+  if (!firstLineOnly) {
+    return error.message;
+  }
+
+  const summary = firstLine(error.message);
+  if (error.cause instanceof Error) {
+    const causeSummary = firstLine(error.cause.message);
+    if (causeSummary.startsWith('Unsupported file format:')) {
+      return `${summary}: ${causeSummary}`;
+    }
+  }
+
+  return summary;
+}
+
+function formatErrorObject(error: unknown, message?: string, firstLineOnly = false): string {
   const formattedMessage: string = message !== undefined && message.length > 0 ? message + ': ' : '';
 
   if (axios.isAxiosError(error)) {
     const formattedCode: string = error.code !== undefined && error.code.length > 0 ? error.code + ' ' : '';
-    logger.error(`${formattedCode}${formattedMessage}${error.message}`);
+    return `${formattedCode}${formattedMessage}${formatErrorDetails(error, firstLineOnly)}`;
   } else if (error instanceof Error) {
-    logger.error(`${formattedMessage}${error.message}`);
-  } else {
-    logger.error(`${message}: unknown error`);
+    return `${formattedMessage}${formatErrorDetails(error, firstLineOnly)}`;
+  }
+
+  return `${message}: unknown error`;
+}
+
+export function logErrorObject(error: unknown, message?: string) {
+  logger.error(formatErrorObject(error, message));
+}
+
+export function logFatalErrorObject(error: unknown, message?: string) {
+  logger.error(formatErrorObject(error, message));
+
+  const logOutput = (process.env.LOG_OUTPUT || 'file').toLowerCase();
+  const loggerWritesErrorsToStderr = ['stderr', 'stderr-all', 'file+stderr'].includes(logOutput);
+  if (!loggerWritesErrorsToStderr) {
+    // Parser errors can include configuration snippets, so only expose their first line.
+    console.error(formatErrorObject(error, message, true));
   }
 }
 


### PR DESCRIPTION
## Summary

- Surface fatal startup failures on stderr even when the configured logger writes only to a file, stdout, or is disabled.
- Preserve the existing full logger entry while keeping the added stderr fallback to a safe single-line summary, so multi-line configuration excerpts are not copied to the terminal.
- Avoid duplicate fallback output when a stderr-based Winston transport is already configured, and keep `LOG_OUTPUT=disabled` silent at the Winston layer.
- Add regression coverage for file logging, stderr transports, unsupported formats, Axios metadata, and disabled logging.

## Root cause

The top-level `main().catch` path only called `logger.error`. With the default `LOG_OUTPUT=file`, Winston has no console transport, so configuration failures exited with status 1 while leaving both stdout and stderr empty.

## Verification

- `npm run prettier`
- `npm run test:unit -- --coverage` — 15 suites, 188 tests passed
- `npx eslint src/index.ts src/utils/logger.ts src/utils/__tests__/logger.test.ts`
- `npm run build`
- `node dist/index.js --help`
- CLI smoke tests for malformed YAML with `LOG_OUTPUT=file` and `LOG_OUTPUT=disabled`: exit 1, stdout empty, exactly one safe stderr line, no interpolated token value

Fixes #225

Assisted by Codex; implementation and verification were reviewed locally.
