### PR TITLE
NOISSUE(chore): normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=lf
+*                               text=auto eol=lf
 
 # Windows-only files keep CRLF
 *.bat                           text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,26 @@
+* text=auto eol=lf
+
 *.ts                            text eol=lf
 *.tsx                           text eol=lf
 *.css                           text eol=lf
 *.html                          text eol=lf
 *.json                          text eol=lf
 *.sh                            text eol=lf
+
+# Windows-only files keep CRLF
+*.bat                           text eol=crlf
+*.cmd                           text eol=crlf
+*.ps1                           text eol=crlf
+
+# Binaries: never touch
+*.png                           binary
+*.jpg                           binary
+*.jpeg                          binary
+*.gif                           binary
+*.ico                           binary
+*.svgz                          binary
+*.pdf                           binary
+*.zip                           binary
+*.gz                            binary
+*.woff                          binary
+*.woff2                         binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,5 @@
 * text=auto eol=lf
 
-*.ts                            text eol=lf
-*.tsx                           text eol=lf
-*.css                           text eol=lf
-*.html                          text eol=lf
-*.json                          text eol=lf
-*.sh                            text eol=lf
-
 # Windows-only files keep CRLF
 *.bat                           text eol=crlf
 *.cmd                           text eol=crlf


### PR DESCRIPTION
This PR enforces LF line endings via .gitattributes for all text files, except Windows-only scripts (.bat, .cmd, .ps1), which keep CRLF, and binary files, which are never converted.

No file contents change (every file is already stored with LF in the repository). This only affects what Git writes to the working tree on checkout.

It fixes the bug on Windows where file types with no .gitattributes rule (e.g. .md, .yml, .js, .mjs) were checked out with CRLF. The pre-commit hook then runs "prettier --write ." over the whole repo, and Prettier's endOfLine: lf rewrote them back to LF. Git then reported all of them as modified, while git diff showed no actual changes, so the working tree had to be cleaned manually after every commit.

No effect on Linux/macOS, which were already LF. 