### PR TITLE
Vuln/PRISM-13818 DNS rebinding no host header validation on http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- Added Host and Origin headers validation. To configure it use `DT_MCP_ALLOWED_HOSTS`, by default it will allow localhost hosts (`localhost`, `127.0.0.1` and `[::1]`)
+
 ### Changes
 
 - Malformed aliases will no longer be printed in logs. Instead, alias index will be printed to point which alias is wrong

--- a/README.md
+++ b/README.md
@@ -430,6 +430,9 @@ npx -y @dynatrace-oss/dynatrace-mcp-server@latest --http --host 192.168.0.1 # re
 npx -y @dynatrace-oss/dynatrace-managed-mcp-server@latest --version
 ```
 
+> [!WARNING]
+> In HTTP mode the server validates the `Host` header to protect against DNS rebinding attacks. With `--host 0.0.0.0` (or `--host ::`) that validation cannot be derived automatically and is **disabled** unless you set `DT_MCP_ALLOWED_HOSTS`. See [DNS Rebinding Protection](#dns-rebinding-protection-http-mode).
+
 **Configuration for MCP clients that support HTTP transport:**
 
 ```json
@@ -563,6 +566,21 @@ LOG_OUTPUT=disabled node dist/index.js
 ```bash
 DT_MCP_RATE_LIMIT_MAX_CALLS=50
 DT_MCP_RATE_LIMIT_WINDOW_MS=30000
+```
+
+### DNS Rebinding Protection (HTTP mode)
+
+- **`DT_MCP_ALLOWED_HOSTS`** (optional): Comma-separated list of hostnames the server accepts in the `Host` header. Ports are ignored, so list hostnames only (use the bracketed form for IPv6, e.g. `[::1]`).
+
+When this variable is **not** set, the allowlist is derived from `--host`: the bound address plus `localhost`, `127.0.0.1` and `[::1]`. Requests whose `Host` header is not on the list are rejected with `403 Forbidden`, as are requests carrying an `Origin` header for a hostname that is not on the list. This is what prevents [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding), where a malicious web page rebinds its own domain to `127.0.0.1` to reach your local MCP server from the victim's browser.
+
+> [!WARNING]
+> When bound to a wildcard address (`--host 0.0.0.0` or `--host ::`), the bound address does not identify which hostnames are legitimate, so **`Host` validation is disabled unless you set `DT_MCP_ALLOWED_HOSTS` explicitly**. The server logs a warning at startup in this case. If you run in a container or expose the server on a network, always set `DT_MCP_ALLOWED_HOSTS` to the hostnames your clients actually use.
+
+**Example:** container bound to all interfaces, reached as `mcp.internal.example.com`:
+
+```bash
+DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com node dist/index.js --http --host 0.0.0.0
 ```
 
 ### Multienvironment Config Fields

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ npx -y @dynatrace-oss/dynatrace-managed-mcp-server@latest --version
 ```
 
 > [!WARNING]
-> In HTTP mode the server validates the `Host` header to protect against DNS rebinding attacks. With `--host 0.0.0.0` (or `--host ::`) that validation cannot be derived automatically and is **disabled** unless you set `DT_MCP_ALLOWED_HOSTS`. See [DNS Rebinding Protection](#dns-rebinding-protection-http-mode).
+> In HTTP mode the server validates the `Host` header to protect against DNS rebinding attacks. With `--host 0.0.0.0` (or `--host ::`) only **loopback** hostnames are accepted by default, so remote clients receive `403 Forbidden` until you set `DT_MCP_ALLOWED_HOSTS` to the hostnames they use. See [DNS Rebinding Protection](#dns-rebinding-protection-http-mode).
 
 **Configuration for MCP clients that support HTTP transport:**
 
@@ -574,13 +574,21 @@ DT_MCP_RATE_LIMIT_WINDOW_MS=30000
 
 When this variable is **not** set, the allowlist is derived from `--host`: the bound address plus `localhost`, `127.0.0.1` and `[::1]`. Requests whose `Host` header is not on the list are rejected with `403 Forbidden`, as are requests carrying an `Origin` header for a hostname that is not on the list. This is what prevents [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding).
 
-> [!WARNING]
-> When bound to a wildcard address (`--host 0.0.0.0` or `--host ::`), the bound address does not identify which hostnames are legitimate, so **`Host` validation is disabled unless you set `DT_MCP_ALLOWED_HOSTS` explicitly**.
+Validation is always active: there is no configuration in which it is silently skipped.
+
+> [!IMPORTANT]
+> When bound to a wildcard address (`--host 0.0.0.0` or `--host ::`), the bound address does not identify which hostnames are legitimate, so the server **accepts loopback hostnames only** and logs a warning at startup. DNS rebinding is blocked in this mode, but so is every remote client. If you run in a container or expose the server on a network, you **must** set `DT_MCP_ALLOWED_HOSTS` to the hostnames your clients use, or they will receive `403 Forbidden`.
 
 **Example:** container bound to all interfaces, reached as `mcp.internal.example.com`:
 
 ```bash
 DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com node dist/index.js --http --host 0.0.0.0
+```
+
+`DT_MCP_ALLOWED_HOSTS` **replaces** the derived list rather than extending it, so include loopback names explicitly if you also need local access:
+
+```bash
+DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com,localhost,127.0.0.1
 ```
 
 ### Multienvironment Config Fields

--- a/README.md
+++ b/README.md
@@ -572,10 +572,10 @@ DT_MCP_RATE_LIMIT_WINDOW_MS=30000
 
 - **`DT_MCP_ALLOWED_HOSTS`** (optional): Comma-separated list of hostnames the server accepts in the `Host` header. Ports are ignored, so list hostnames only (use the bracketed form for IPv6, e.g. `[::1]`).
 
-When this variable is **not** set, the allowlist is derived from `--host`: the bound address plus `localhost`, `127.0.0.1` and `[::1]`. Requests whose `Host` header is not on the list are rejected with `403 Forbidden`, as are requests carrying an `Origin` header for a hostname that is not on the list. This is what prevents [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding), where a malicious web page rebinds its own domain to `127.0.0.1` to reach your local MCP server from the victim's browser.
+When this variable is **not** set, the allowlist is derived from `--host`: the bound address plus `localhost`, `127.0.0.1` and `[::1]`. Requests whose `Host` header is not on the list are rejected with `403 Forbidden`, as are requests carrying an `Origin` header for a hostname that is not on the list. This is what prevents [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding).
 
 > [!WARNING]
-> When bound to a wildcard address (`--host 0.0.0.0` or `--host ::`), the bound address does not identify which hostnames are legitimate, so **`Host` validation is disabled unless you set `DT_MCP_ALLOWED_HOSTS` explicitly**. The server logs a warning at startup in this case. If you run in a container or expose the server on a network, always set `DT_MCP_ALLOWED_HOSTS` to the hostnames your clients actually use.
+> When bound to a wildcard address (`--host 0.0.0.0` or `--host ::`), the bound address does not identify which hostnames are legitimate, so **`Host` validation is disabled unless you set `DT_MCP_ALLOWED_HOSTS` explicitly**.
 
 **Example:** container bound to all interfaces, reached as `mcp.internal.example.com`:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,12 @@ import {
 } from './authentication/managed-auth-client';
 import { getManagedEnvironmentConfigs, validateEnvironments, buildConfigTokenMap } from './utils/environment';
 import { parseTokenHeader, deriveUserKey } from './utils/token-header';
-import { buildAllowedHostnames, validateRequestHeaders } from './utils/host-validation';
+import {
+  buildAllowedHostnames,
+  hasExplicitAllowlist,
+  isWildcardBindAddress,
+  validateRequestHeaders,
+} from './utils/host-validation';
 import { createAndInitializeTelemetry } from './utils/telemetry-openkit';
 import { MetricsApiClient } from './capabilities/metrics-api';
 import { LogsApiClient } from './capabilities/logs-api';
@@ -317,6 +322,8 @@ const main = async () => {
   // HTTP server mode (Stateless)
   if (httpMode) {
     const allowedHostnames = buildAllowedHostnames(host, process.env.DT_MCP_ALLOWED_HOSTS);
+    const needsExplicitAllowlist =
+      isWildcardBindAddress(host) && !hasExplicitAllowlist(process.env.DT_MCP_ALLOWED_HOSTS);
 
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
       const rejection = validateRequestHeaders(req.headers.host, req.headers.origin, allowedHostnames);
@@ -412,14 +419,13 @@ const main = async () => {
     // Start HTTP Server on the specified host and port
     httpServer.listen(httpPort, host, () => {
       logger.info(`Dynatrace Managed MCP Server running on HTTP at http://${host}:${httpPort}`);
-      if (allowedHostnames.length > 0) {
-        logger.info(`DNS rebinding protection active; allowed Host headers: ${allowedHostnames.join(', ')}`);
-      } else {
+      logger.info(`DNS rebinding protection active; allowed Host headers: ${allowedHostnames.join(', ')}`);
+      if (needsExplicitAllowlist) {
         const warning =
           `WARNING: the server is bound to a wildcard address (${host}) without DT_MCP_ALLOWED_HOSTS set, ` +
-          `so Host header validation is DISABLED and the server is exposed to DNS rebinding attacks. ` +
-          `Set DT_MCP_ALLOWED_HOSTS to a comma-separated list of the hostnames clients use ` +
-          `(e.g. DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com).`;
+          `so only loopback Host headers (${allowedHostnames.join(', ')}) are accepted and requests using ` +
+          `any other hostname will be rejected with 403. Set DT_MCP_ALLOWED_HOSTS to a comma-separated list ` +
+          `of the hostnames clients actually use (e.g. DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com).`;
         logger.warn(warning);
         console.error(warning);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,13 +316,9 @@ const main = async () => {
 
   // HTTP server mode (Stateless)
   if (httpMode) {
-    // DNS rebinding protection. Derived from the bound host unless the operator overrides it with
-    // DT_MCP_ALLOWED_HOSTS. Empty means "not determinable" (wildcard bind, no override).
     const allowedHostnames = buildAllowedHostnames(host, process.env.DT_MCP_ALLOWED_HOSTS);
 
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      // Reject before reading the body or touching tokens: this is the cheapest possible rejection
-      // and keeps unvalidated requests from reaching any MCP tool.
       const rejection = validateRequestHeaders(req.headers.host, req.headers.origin, allowedHostnames);
       if (rejection) {
         logger.warn(`Rejected request failing DNS rebinding protection: ${rejection.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,11 +419,11 @@ const main = async () => {
     // Start HTTP Server on the specified host and port
     httpServer.listen(httpPort, host, () => {
       logger.info(`Dynatrace Managed MCP Server running on HTTP at http://${host}:${httpPort}`);
-      logger.info(`DNS rebinding protection active; allowed Host headers: ${allowedHostnames.join(', ')}`);
+      logger.info(`DNS rebinding protection active; allowed Host headers: ${[...allowedHostnames].join(', ')}`);
       if (needsExplicitAllowlist) {
         const warning =
           `WARNING: the server is bound to a wildcard address (${host}) without DT_MCP_ALLOWED_HOSTS set, ` +
-          `so only loopback Host headers (${allowedHostnames.join(', ')}) are accepted and requests using ` +
+          `so only loopback Host headers (${[...allowedHostnames].join(', ')}) are accepted and requests using ` +
           `any other hostname will be rejected with 403. Set DT_MCP_ALLOWED_HOSTS to a comma-separated list ` +
           `of the hostnames clients actually use (e.g. DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com).`;
         logger.warn(warning);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from './authentication/managed-auth-client';
 import { getManagedEnvironmentConfigs, validateEnvironments, buildConfigTokenMap } from './utils/environment';
 import { parseTokenHeader, deriveUserKey } from './utils/token-header';
+import { buildAllowedHostnames, validateRequestHeaders } from './utils/host-validation';
 import { createAndInitializeTelemetry } from './utils/telemetry-openkit';
 import { MetricsApiClient } from './capabilities/metrics-api';
 import { LogsApiClient } from './capabilities/logs-api';
@@ -315,7 +316,27 @@ const main = async () => {
 
   // HTTP server mode (Stateless)
   if (httpMode) {
+    // DNS rebinding protection. Derived from the bound host unless the operator overrides it with
+    // DT_MCP_ALLOWED_HOSTS. Empty means "not determinable" (wildcard bind, no override).
+    const allowedHostnames = buildAllowedHostnames(host, process.env.DT_MCP_ALLOWED_HOSTS);
+
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      // Reject before reading the body or touching tokens: this is the cheapest possible rejection
+      // and keeps unvalidated requests from reaching any MCP tool.
+      const rejection = validateRequestHeaders(req.headers.host, req.headers.origin, allowedHostnames);
+      if (rejection) {
+        logger.warn(`Rejected request failing DNS rebinding protection: ${rejection.message}`);
+        res.writeHead(rejection.status, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32000, message: rejection.message },
+          }),
+        );
+        return;
+      }
+
       const tokenHeader = req.headers['x-dynatrace-tokens'];
       const tokenMap = parseTokenHeader(tokenHeader);
       const userKey = deriveUserKey(Array.isArray(tokenHeader) ? tokenHeader.join(';') : tokenHeader);
@@ -395,6 +416,17 @@ const main = async () => {
     // Start HTTP Server on the specified host and port
     httpServer.listen(httpPort, host, () => {
       logger.info(`Dynatrace Managed MCP Server running on HTTP at http://${host}:${httpPort}`);
+      if (allowedHostnames.length > 0) {
+        logger.info(`DNS rebinding protection active; allowed Host headers: ${allowedHostnames.join(', ')}`);
+      } else {
+        const warning =
+          `WARNING: the server is bound to a wildcard address (${host}) without DT_MCP_ALLOWED_HOSTS set, ` +
+          `so Host header validation is DISABLED and the server is exposed to DNS rebinding attacks. ` +
+          `Set DT_MCP_ALLOWED_HOSTS to a comma-separated list of the hostnames clients use ` +
+          `(e.g. DT_MCP_ALLOWED_HOSTS=mcp.internal.example.com).`;
+        logger.warn(warning);
+        console.error(warning);
+      }
     });
 
     // Handle graceful shutdown for http server mode

--- a/src/utils/__tests__/host-validation.test.ts
+++ b/src/utils/__tests__/host-validation.test.ts
@@ -1,0 +1,127 @@
+import {
+  buildAllowedHostnames,
+  isWildcardBindAddress,
+  normalizeHostname,
+  validateRequestHeaders,
+} from '../host-validation';
+
+describe('normalizeHostname', () => {
+  it('strips the port', () => {
+    expect(normalizeHostname('127.0.0.1:3000')).toBe('127.0.0.1');
+    expect(normalizeHostname('example.com:8080')).toBe('example.com');
+  });
+
+  it('returns IPv6 in bracketed form, from either input form', () => {
+    expect(normalizeHostname('[::1]:3000')).toBe('[::1]');
+    expect(normalizeHostname('[::1]')).toBe('[::1]');
+    expect(normalizeHostname('::1')).toBe('[::1]');
+  });
+
+  it('lowercases and trims', () => {
+    expect(normalizeHostname('  LocalHost:3000 ')).toBe('localhost');
+  });
+
+  it('returns undefined for unusable values', () => {
+    expect(normalizeHostname(undefined)).toBeUndefined();
+    expect(normalizeHostname('')).toBeUndefined();
+    expect(normalizeHostname('   ')).toBeUndefined();
+    expect(normalizeHostname('/')).toBeUndefined();
+  });
+});
+
+describe('isWildcardBindAddress', () => {
+  it('detects wildcard binds', () => {
+    expect(isWildcardBindAddress('0.0.0.0')).toBe(true);
+    expect(isWildcardBindAddress('::')).toBe(true);
+    expect(isWildcardBindAddress('[::]')).toBe(true);
+  });
+
+  it('does not flag concrete addresses', () => {
+    expect(isWildcardBindAddress('127.0.0.1')).toBe(false);
+    expect(isWildcardBindAddress('192.168.0.1')).toBe(false);
+    expect(isWildcardBindAddress(undefined)).toBe(false);
+  });
+});
+
+describe('buildAllowedHostnames', () => {
+  it('derives loopback names for the default bind', () => {
+    expect(buildAllowedHostnames('127.0.0.1')).toEqual(['127.0.0.1', 'localhost', '[::1]']);
+  });
+
+  it('includes a LAN bind address alongside loopback names', () => {
+    expect(buildAllowedHostnames('192.168.0.1')).toEqual(['192.168.0.1', 'localhost', '127.0.0.1', '[::1]']);
+  });
+
+  it('returns an empty list for a wildcard bind with no override', () => {
+    expect(buildAllowedHostnames('0.0.0.0')).toEqual([]);
+    expect(buildAllowedHostnames('::')).toEqual([]);
+  });
+
+  it('lets an override win, including for wildcard binds', () => {
+    expect(buildAllowedHostnames('0.0.0.0', 'mcp.example.com')).toEqual(['mcp.example.com']);
+    expect(buildAllowedHostnames('127.0.0.1', 'mcp.example.com')).toEqual(['mcp.example.com']);
+  });
+
+  it('parses, normalizes and dedupes override lists', () => {
+    expect(buildAllowedHostnames('0.0.0.0', ' A.example.com:3000 , b.example.com , a.example.com ')).toEqual([
+      'a.example.com',
+      'b.example.com',
+    ]);
+  });
+
+  it('ignores an override that contains nothing usable', () => {
+    expect(buildAllowedHostnames('127.0.0.1', '  ,  ')).toEqual(['127.0.0.1', 'localhost', '[::1]']);
+  });
+});
+
+describe('validateRequestHeaders', () => {
+  const allowed = buildAllowedHostnames('127.0.0.1');
+
+  it('accepts an allowed Host with no Origin (typical MCP client)', () => {
+    expect(validateRequestHeaders('127.0.0.1:3000', undefined, allowed)).toBeUndefined();
+    expect(validateRequestHeaders('localhost:3000', undefined, allowed)).toBeUndefined();
+    expect(validateRequestHeaders('[::1]:3000', undefined, allowed)).toBeUndefined();
+  });
+
+  it('rejects the DNS rebinding Host from the report', () => {
+    const rejection = validateRequestHeaders('local.firstnamelastname.com', undefined, allowed);
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.message).toContain('Invalid Host');
+  });
+
+  it('rejects a missing Host header', () => {
+    expect(validateRequestHeaders(undefined, undefined, allowed)?.message).toBe('Missing Host header');
+    expect(validateRequestHeaders('   ', undefined, allowed)?.message).toBe('Missing Host header');
+  });
+
+  it('rejects an unparseable Host header', () => {
+    expect(validateRequestHeaders('/', undefined, allowed)?.status).toBe(403);
+  });
+
+  it('rejects a mismatched Origin even when Host is allowed', () => {
+    const rejection = validateRequestHeaders('127.0.0.1:3000', 'http://local.firstnamelastname.com:3000', allowed);
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.message).toContain('Invalid Origin');
+  });
+
+  it('rejects a null / unparseable Origin', () => {
+    expect(validateRequestHeaders('127.0.0.1:3000', 'null', allowed)?.message).toContain('Invalid Origin');
+  });
+
+  it('accepts a matching Origin regardless of port', () => {
+    expect(validateRequestHeaders('127.0.0.1:3000', 'http://127.0.0.1:3000', allowed)).toBeUndefined();
+    expect(validateRequestHeaders('localhost:3000', 'http://localhost:3000', allowed)).toBeUndefined();
+  });
+
+  it('treats an empty allowlist as validation disabled', () => {
+    expect(
+      validateRequestHeaders('local.firstnamelastname.com', 'http://local.firstnamelastname.com', []),
+    ).toBeUndefined();
+  });
+
+  it('truncates and flattens attacker-controlled values in the message', () => {
+    const rejection = validateRequestHeaders(`evil${'a'.repeat(200)}.com`, undefined, allowed);
+    expect(rejection?.message.length).toBeLessThan(140);
+    expect(rejection?.message).not.toMatch(/[\r\n]/);
+  });
+});

--- a/src/utils/__tests__/host-validation.test.ts
+++ b/src/utils/__tests__/host-validation.test.ts
@@ -128,7 +128,6 @@ describe('validateRequestHeaders', () => {
     );
     expect(rejection?.status).toBe(403);
     expect(rejection?.message).toBe('Host validation is not configured');
-    // Even an otherwise-legitimate request is refused, so the misconfiguration cannot go unnoticed.
     expect(validateRequestHeaders('127.0.0.1:3000', undefined, new Set())?.status).toBe(403);
   });
 
@@ -136,8 +135,17 @@ describe('validateRequestHeaders', () => {
     const wildcard = buildAllowedHostnames('0.0.0.0', undefined);
     expect(validateRequestHeaders('local.attacker.example', undefined, wildcard)?.status).toBe(403);
     expect(validateRequestHeaders('127.0.0.1:3000', 'http://local.attacker.example:3000', wildcard)?.status).toBe(403);
-    // Loopback access still works, so running with --host 0.0.0.0 locally is unaffected.
     expect(validateRequestHeaders('localhost:3000', undefined, wildcard)).toBeUndefined();
+  });
+
+  it('rejects the comma-joined value Node produces for duplicate headers', () => {
+    expect(validateRequestHeaders('127.0.0.1:3000, evil.example', undefined, allowed)?.status).toBe(403);
+    expect(
+      validateRequestHeaders('127.0.0.1:3000', 'http://127.0.0.1:3000, http://evil.example', allowed)?.status,
+    ).toBe(403);
+    expect(
+      validateRequestHeaders('127.0.0.1:3000', 'http://evil.example, http://127.0.0.1:3000', allowed)?.status,
+    ).toBe(403);
   });
 
   it('truncates and flattens attacker-controlled values in the message', () => {

--- a/src/utils/__tests__/host-validation.test.ts
+++ b/src/utils/__tests__/host-validation.test.ts
@@ -46,39 +46,38 @@ describe('isWildcardBindAddress', () => {
 
 describe('buildAllowedHostnames', () => {
   it('derives loopback names for the default bind', () => {
-    expect(buildAllowedHostnames('127.0.0.1')).toEqual(['127.0.0.1', 'localhost', '[::1]']);
+    expect(buildAllowedHostnames('127.0.0.1')).toEqual(new Set(['127.0.0.1', 'localhost', '[::1]']));
   });
 
   it('includes a LAN bind address alongside loopback names', () => {
-    expect(buildAllowedHostnames('192.168.0.1')).toEqual(['192.168.0.1', 'localhost', '127.0.0.1', '[::1]']);
+    expect(buildAllowedHostnames('192.168.0.1')).toEqual(new Set(['192.168.0.1', 'localhost', '127.0.0.1', '[::1]']));
   });
 
   it('falls back to loopback only for a wildcard bind with no override', () => {
-    expect(buildAllowedHostnames('0.0.0.0')).toEqual(['localhost', '127.0.0.1', '[::1]']);
-    expect(buildAllowedHostnames('::')).toEqual(['localhost', '127.0.0.1', '[::1]']);
+    expect(buildAllowedHostnames('0.0.0.0')).toEqual(new Set(['localhost', '127.0.0.1', '[::1]']));
+    expect(buildAllowedHostnames('::')).toEqual(new Set(['localhost', '127.0.0.1', '[::1]']));
   });
 
   it('never returns an empty list, so validation can never be silently disabled', () => {
     for (const boundHost of ['0.0.0.0', '::', '[::]', '127.0.0.1', '192.168.0.1', undefined, '', 'nonsense/host']) {
-      expect(buildAllowedHostnames(boundHost, undefined).length).toBeGreaterThan(0);
-      expect(buildAllowedHostnames(boundHost, '  ,  ').length).toBeGreaterThan(0);
+      expect(buildAllowedHostnames(boundHost, undefined).size).toBeGreaterThan(0);
+      expect(buildAllowedHostnames(boundHost, '  ,  ').size).toBeGreaterThan(0);
     }
   });
 
   it('lets an override win, including for wildcard binds', () => {
-    expect(buildAllowedHostnames('0.0.0.0', 'mcp.example.com')).toEqual(['mcp.example.com']);
-    expect(buildAllowedHostnames('127.0.0.1', 'mcp.example.com')).toEqual(['mcp.example.com']);
+    expect(buildAllowedHostnames('0.0.0.0', 'mcp.example.com')).toEqual(new Set(['mcp.example.com']));
+    expect(buildAllowedHostnames('127.0.0.1', 'mcp.example.com')).toEqual(new Set(['mcp.example.com']));
   });
 
   it('parses, normalizes and dedupes override lists', () => {
-    expect(buildAllowedHostnames('0.0.0.0', ' A.example.com:3000 , b.example.com , a.example.com ')).toEqual([
-      'a.example.com',
-      'b.example.com',
-    ]);
+    const deduped = buildAllowedHostnames('0.0.0.0', ' A.example.com:3000 , b.example.com , a.example.com ');
+    expect(deduped).toEqual(new Set(['a.example.com', 'b.example.com']));
+    expect(deduped.size).toBe(2);
   });
 
   it('ignores an override that contains nothing usable', () => {
-    expect(buildAllowedHostnames('127.0.0.1', '  ,  ')).toEqual(['127.0.0.1', 'localhost', '[::1]']);
+    expect(buildAllowedHostnames('127.0.0.1', '  ,  ')).toEqual(new Set(['127.0.0.1', 'localhost', '[::1]']));
   });
 });
 
@@ -122,11 +121,15 @@ describe('validateRequestHeaders', () => {
   });
 
   it('fails closed on an empty allowlist rather than allowing the request', () => {
-    const rejection = validateRequestHeaders('local.firstnamelastname.com', 'http://local.firstnamelastname.com', []);
+    const rejection = validateRequestHeaders(
+      'local.firstnamelastname.com',
+      'http://local.firstnamelastname.com',
+      new Set(),
+    );
     expect(rejection?.status).toBe(403);
     expect(rejection?.message).toBe('Host validation is not configured');
     // Even an otherwise-legitimate request is refused, so the misconfiguration cannot go unnoticed.
-    expect(validateRequestHeaders('127.0.0.1:3000', undefined, [])?.status).toBe(403);
+    expect(validateRequestHeaders('127.0.0.1:3000', undefined, new Set())?.status).toBe(403);
   });
 
   it('blocks the reported attack on a wildcard bind with no override', () => {

--- a/src/utils/__tests__/host-validation.test.ts
+++ b/src/utils/__tests__/host-validation.test.ts
@@ -1,5 +1,6 @@
 import {
   buildAllowedHostnames,
+  hasExplicitAllowlist,
   isWildcardBindAddress,
   normalizeHostname,
   validateRequestHeaders,
@@ -52,9 +53,16 @@ describe('buildAllowedHostnames', () => {
     expect(buildAllowedHostnames('192.168.0.1')).toEqual(['192.168.0.1', 'localhost', '127.0.0.1', '[::1]']);
   });
 
-  it('returns an empty list for a wildcard bind with no override', () => {
-    expect(buildAllowedHostnames('0.0.0.0')).toEqual([]);
-    expect(buildAllowedHostnames('::')).toEqual([]);
+  it('falls back to loopback only for a wildcard bind with no override', () => {
+    expect(buildAllowedHostnames('0.0.0.0')).toEqual(['localhost', '127.0.0.1', '[::1]']);
+    expect(buildAllowedHostnames('::')).toEqual(['localhost', '127.0.0.1', '[::1]']);
+  });
+
+  it('never returns an empty list, so validation can never be silently disabled', () => {
+    for (const boundHost of ['0.0.0.0', '::', '[::]', '127.0.0.1', '192.168.0.1', undefined, '', 'nonsense/host']) {
+      expect(buildAllowedHostnames(boundHost, undefined).length).toBeGreaterThan(0);
+      expect(buildAllowedHostnames(boundHost, '  ,  ').length).toBeGreaterThan(0);
+    }
   });
 
   it('lets an override win, including for wildcard binds', () => {
@@ -113,15 +121,38 @@ describe('validateRequestHeaders', () => {
     expect(validateRequestHeaders('localhost:3000', 'http://localhost:3000', allowed)).toBeUndefined();
   });
 
-  it('treats an empty allowlist as validation disabled', () => {
-    expect(
-      validateRequestHeaders('local.firstnamelastname.com', 'http://local.firstnamelastname.com', []),
-    ).toBeUndefined();
+  it('fails closed on an empty allowlist rather than allowing the request', () => {
+    const rejection = validateRequestHeaders('local.firstnamelastname.com', 'http://local.firstnamelastname.com', []);
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.message).toBe('Host validation is not configured');
+    // Even an otherwise-legitimate request is refused, so the misconfiguration cannot go unnoticed.
+    expect(validateRequestHeaders('127.0.0.1:3000', undefined, [])?.status).toBe(403);
+  });
+
+  it('blocks the reported attack on a wildcard bind with no override', () => {
+    const wildcard = buildAllowedHostnames('0.0.0.0', undefined);
+    expect(validateRequestHeaders('local.attacker.example', undefined, wildcard)?.status).toBe(403);
+    expect(validateRequestHeaders('127.0.0.1:3000', 'http://local.attacker.example:3000', wildcard)?.status).toBe(403);
+    // Loopback access still works, so running with --host 0.0.0.0 locally is unaffected.
+    expect(validateRequestHeaders('localhost:3000', undefined, wildcard)).toBeUndefined();
   });
 
   it('truncates and flattens attacker-controlled values in the message', () => {
     const rejection = validateRequestHeaders(`evil${'a'.repeat(200)}.com`, undefined, allowed);
     expect(rejection?.message.length).toBeLessThan(140);
     expect(rejection?.message).not.toMatch(/[\r\n]/);
+  });
+});
+
+describe('hasExplicitAllowlist', () => {
+  it('is true only when the override contains a usable hostname', () => {
+    expect(hasExplicitAllowlist('mcp.example.com')).toBe(true);
+    expect(hasExplicitAllowlist(' a.example.com , b.example.com ')).toBe(true);
+  });
+
+  it('is false for absent or unusable overrides', () => {
+    expect(hasExplicitAllowlist(undefined)).toBe(false);
+    expect(hasExplicitAllowlist('')).toBe(false);
+    expect(hasExplicitAllowlist('  ,  ')).toBe(false);
   });
 });

--- a/src/utils/__tests__/host-validation.test.ts
+++ b/src/utils/__tests__/host-validation.test.ts
@@ -6,6 +6,8 @@ import {
   validateRequestHeaders,
 } from '../host-validation';
 
+const BACKSLASH = String.fromCharCode(92);
+
 describe('normalizeHostname', () => {
   it('strips the port', () => {
     expect(normalizeHostname('127.0.0.1:3000')).toBe('127.0.0.1');
@@ -20,6 +22,26 @@ describe('normalizeHostname', () => {
 
   it('lowercases and trims', () => {
     expect(normalizeHostname('  LocalHost:3000 ')).toBe('localhost');
+  });
+
+  it('rejects anything that is not a bare authority', () => {
+    expect(normalizeHostname('evil.example@127.0.0.1')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1@evil.example')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1/evil.example')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1?x=evil')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1#evil')).toBeUndefined();
+    expect(normalizeHostname(`127.0.0.1${BACKSLASH}evil.example`)).toBeUndefined();
+    expect(normalizeHostname('http://127.0.0.1')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1 evil')).toBeUndefined();
+    expect(normalizeHostname('127.0.0.1	evil')).toBeUndefined();
+  });
+
+  it('still accepts every legitimate authority form', () => {
+    expect(normalizeHostname('127.0.0.1')).toBe('127.0.0.1');
+    expect(normalizeHostname('localhost:3000')).toBe('localhost');
+    expect(normalizeHostname('mcp.internal.example.com:8080')).toBe('mcp.internal.example.com');
+    expect(normalizeHostname('[::1]:3000')).toBe('[::1]');
+    expect(normalizeHostname('::1')).toBe('[::1]');
   });
 
   it('returns undefined for unusable values', () => {
@@ -109,6 +131,31 @@ describe('validateRequestHeaders', () => {
     const rejection = validateRequestHeaders('127.0.0.1:3000', 'http://local.firstnamelastname.com:3000', allowed);
     expect(rejection?.status).toBe(403);
     expect(rejection?.message).toContain('Invalid Origin');
+  });
+
+  it('rejects a Host that smuggles the allowed name into another URL component', () => {
+    for (const host of [
+      'evil.example@127.0.0.1',
+      '127.0.0.1/evil.example',
+      '127.0.0.1?x=evil',
+      '127.0.0.1#evil',
+      `127.0.0.1${BACKSLASH}evil.example`,
+    ]) {
+      expect(validateRequestHeaders(host, undefined, allowed)?.status).toBe(403);
+    }
+  });
+
+  it('rejects an Origin that is not a bare origin', () => {
+    for (const origin of [
+      'http://evil.example@127.0.0.1:3000',
+      'http://127.0.0.1:3000/evil',
+      'http://127.0.0.1:3000?x=1',
+      'http://127.0.0.1:3000#f',
+    ]) {
+      expect(validateRequestHeaders('127.0.0.1:3000', origin, allowed)?.status).toBe(403);
+    }
+    expect(validateRequestHeaders('127.0.0.1:3000', 'http://127.0.0.1:3000', allowed)).toBeUndefined();
+    expect(validateRequestHeaders('127.0.0.1:3000', 'http://127.0.0.1:3000/', allowed)).toBeUndefined();
   });
 
   it('rejects a null / unparseable Origin', () => {

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -1,0 +1,160 @@
+/**
+ * DNS rebinding protection for HTTP mode.
+ *
+ * A DNS rebinding attack works like this: the victim loads a page from an attacker-controlled
+ * domain served on the same port this server listens on, then the attacker rebinds that domain
+ * to 127.0.0.1. Because scheme, host and port still match the page's origin, the browser treats
+ * the follow-up `fetch()` calls as same-origin — no CORS preflight, no CORS check. The only
+ * remaining signal is that the `Host` header still carries the attacker's domain, so validating
+ * it is what stops the attack.
+ *
+ * The MCP SDK exposes two opt-in mechanisms for this, neither of which fits here:
+ *   - `allowedHosts` / `enableDnsRebindingProtection` on `StreamableHTTPServerTransport` are
+ *     deprecated as of SDK 1.30.0 in favour of external middleware.
+ *   - the bundled `hostHeaderValidation` middleware is Express-only (it calls
+ *     `res.status().json()`), while this server runs on a raw `node:http` server.
+ *
+ * So we replicate the SDK middleware's semantics — port-agnostic hostname comparison, 403 with a
+ * JSON-RPC error body — in a form that works with `node:http`.
+ */
+
+/** Hostnames that always mean "this machine", in the form `new URL().hostname` returns. */
+const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
+
+/**
+ * Bind addresses that accept traffic on every interface. When bound to one of these, the bound
+ * address says nothing about which `Host` values are legitimate, so the allowlist cannot be
+ * derived and has to be supplied by the operator.
+ */
+const WILDCARD_BIND_ADDRESSES = ['0.0.0.0', '::', '[::]'];
+
+/** Rejection details for a request that failed Host/Origin validation. */
+export interface HostValidationRejection {
+  status: number;
+  message: string;
+}
+
+/** True when `host` is a wildcard bind address (`0.0.0.0`, `::`). */
+export function isWildcardBindAddress(host: string | undefined): boolean {
+  const normalized = normalizeHostname(host);
+  return normalized !== undefined && WILDCARD_BIND_ADDRESSES.includes(normalized);
+}
+
+/**
+ * Normalize a `Host`-header-style value (`example.com:3000`, `127.0.0.1`, `[::1]:3000`) to a
+ * bare, lowercased hostname with the port stripped. Returns `undefined` if it cannot be parsed.
+ *
+ * Note that IPv6 comes back bracketed (`[::1]`), matching the SDK — an allowlist entry of `::1`
+ * would never match, which is why callers should use the bracketed form.
+ */
+export function normalizeHostname(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+
+  const candidates = [trimmed];
+  // A bare IPv6 literal ('::1') is not a valid URL authority, but its bracketed form is. Accept
+  // both so `--host ::1` behaves the same as `--host [::1]`.
+  if (!trimmed.startsWith('[') && (trimmed.match(/:/g)?.length ?? 0) > 1) {
+    candidates.push(`[${trimmed}]`);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const { hostname } = new URL(`http://${candidate}`);
+      if (hostname !== '') {
+        return hostname.toLowerCase();
+      }
+    } catch {
+      // Not a parseable authority in this form — fall through to the next candidate.
+    }
+  }
+  return undefined;
+}
+
+/** Parse the hostname out of an `Origin` header (a full origin such as `http://host:3000`). */
+function normalizeOriginHostname(origin: string): string | undefined {
+  try {
+    const { hostname } = new URL(origin.trim());
+    return hostname === '' ? undefined : hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build the list of hostnames this server accepts in the `Host` header.
+ *
+ * `override` is a comma-separated operator-supplied list (`DT_MCP_ALLOWED_HOSTS`) and wins
+ * outright when set. Otherwise the list is derived from the bound host plus the loopback names.
+ *
+ * Returns an empty array to mean "cannot be determined" — bound to a wildcard address with no
+ * override — which callers treat as validation disabled.
+ */
+export function buildAllowedHostnames(boundHost: string | undefined, override?: string): string[] {
+  const fromOverride = (override ?? '')
+    .split(',')
+    .map((entry) => normalizeHostname(entry))
+    .filter((entry): entry is string => entry !== undefined);
+  if (fromOverride.length > 0) {
+    return [...new Set(fromOverride)];
+  }
+
+  if (isWildcardBindAddress(boundHost)) {
+    return [];
+  }
+
+  const bound = normalizeHostname(boundHost);
+  // Loopback names are safe to include even for a LAN bind: `Host` is derived from the URL the
+  // browser was pointed at, so an attacker cannot keep their own origin while sending `localhost`.
+  return [...new Set([...(bound ? [bound] : []), ...LOOPBACK_HOSTNAMES])];
+}
+
+/** Truncate attacker-controlled header values before they reach a response body or the log. */
+function forDisplay(value: string): string {
+  const collapsed = value.replace(/[\r\n]+/g, ' ').trim();
+  return collapsed.length > 100 ? `${collapsed.slice(0, 100)}...` : collapsed;
+}
+
+/**
+ * Validate the `Host` and `Origin` headers of an incoming request.
+ *
+ * Returns `undefined` when the request is acceptable, or the rejection to send back. An empty
+ * `allowedHostnames` disables validation entirely (wildcard bind with no operator allowlist).
+ */
+export function validateRequestHeaders(
+  hostHeader: string | undefined,
+  originHeader: string | undefined,
+  allowedHostnames: string[],
+): HostValidationRejection | undefined {
+  if (allowedHostnames.length === 0) {
+    return undefined;
+  }
+
+  if (!hostHeader || hostHeader.trim() === '') {
+    return { status: 403, message: 'Missing Host header' };
+  }
+  const hostname = normalizeHostname(hostHeader);
+  if (!hostname) {
+    return { status: 403, message: `Invalid Host header: ${forDisplay(hostHeader)}` };
+  }
+  if (!allowedHostnames.includes(hostname)) {
+    return { status: 403, message: `Invalid Host: ${forDisplay(hostname)}` };
+  }
+
+  // Second layer. Non-browser MCP clients do not send `Origin`, so an absent one is normal and
+  // allowed. A browser always sends it, and a DNS-rebound page still carries the attacker's
+  // origin — so rejecting unknown origins blocks the attack independently of the Host check.
+  if (originHeader !== undefined && originHeader.trim() !== '') {
+    const originHostname = normalizeOriginHostname(originHeader);
+    if (!originHostname || !allowedHostnames.includes(originHostname)) {
+      return { status: 403, message: `Invalid Origin: ${forDisplay(originHeader)}` };
+    }
+  }
+
+  return undefined;
+}

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -12,12 +12,14 @@ export function isWildcardBindAddress(host: string | undefined): boolean {
   return normalized !== undefined && WILDCARD_BIND_ADDRESSES.has(normalized);
 }
 
+const NON_AUTHORITY_CHARACTERS = /[@/\\?#\s]/;
+
 export function normalizeHostname(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
   const trimmed = value.trim();
-  if (trimmed === '') {
+  if (trimmed === '' || NON_AUTHORITY_CHARACTERS.test(trimmed)) {
     return undefined;
   }
 
@@ -40,12 +42,19 @@ export function normalizeHostname(value: string | undefined): string | undefined
 }
 
 function normalizeOriginHostname(origin: string): string | undefined {
+  let url: URL;
   try {
-    const { hostname } = new URL(origin.trim());
-    return hostname === '' ? undefined : hostname.toLowerCase();
+    url = new URL(origin.trim());
   } catch {
     return undefined;
   }
+  if (url.username !== '' || url.password !== '' || url.search !== '' || url.hash !== '') {
+    return undefined;
+  }
+  if (url.pathname !== '/' && url.pathname !== '') {
+    return undefined;
+  }
+  return url.hostname === '' ? undefined : url.hostname.toLowerCase();
 }
 
 function parseAllowlistOverride(override: string | undefined): string[] {

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
 const WILDCARD_BIND_ADDRESSES = new Set(['0.0.0.0', '::', '[::]']);
@@ -30,9 +32,16 @@ export function normalizeHostname(value: string | undefined): string | undefined
 
   for (const candidate of candidates) {
     try {
-      const { hostname } = new URL(`http://${candidate}`);
-      if (hostname !== '') {
-        return hostname.toLowerCase();
+      const url = new URL(`http://${candidate}`);
+      if (
+        url.hostname !== '' &&
+        url.username === '' &&
+        url.password === '' &&
+        url.pathname === '/' &&
+        url.search === '' &&
+        url.hash === ''
+      ) {
+        return url.hostname.toLowerCase();
       }
     } catch {
       // Not a parseable authority in this form — fall through to the next candidate.
@@ -73,6 +82,7 @@ export function buildAllowedHostnames(boundHost: string | undefined, override?: 
   if (fromOverride.length > 0) {
     return new Set(fromOverride);
   }
+  logger.warn('DT_MCP_ALLOWED_HOSTS is empty or not set. Falling back to default allowed hosts.');
 
   if (isWildcardBindAddress(boundHost)) {
     return new Set(LOOPBACK_HOSTNAMES);

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -1,52 +1,17 @@
-/**
- * DNS rebinding protection for HTTP mode.
- *
- * A DNS rebinding attack works like this: the victim loads a page from an attacker-controlled
- * domain served on the same port this server listens on, then the attacker rebinds that domain
- * to 127.0.0.1. Because scheme, host and port still match the page's origin, the browser treats
- * the follow-up `fetch()` calls as same-origin — no CORS preflight, no CORS check. The only
- * remaining signal is that the `Host` header still carries the attacker's domain, so validating
- * it is what stops the attack.
- *
- * The MCP SDK exposes two opt-in mechanisms for this, neither of which fits here:
- *   - `allowedHosts` / `enableDnsRebindingProtection` on `StreamableHTTPServerTransport` are
- *     deprecated as of SDK 1.30.0 in favour of external middleware.
- *   - the bundled `hostHeaderValidation` middleware is Express-only (it calls
- *     `res.status().json()`), while this server runs on a raw `node:http` server.
- *
- * So we replicate the SDK middleware's semantics — port-agnostic hostname comparison, 403 with a
- * JSON-RPC error body — in a form that works with `node:http`.
- */
-
-/** Hostnames that always mean "this machine", in the form `new URL().hostname` returns. */
 const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
-/**
- * Bind addresses that accept traffic on every interface. When bound to one of these, the bound
- * address says nothing about which `Host` values are legitimate, so the allowlist cannot be
- * derived and has to be supplied by the operator.
- */
 const WILDCARD_BIND_ADDRESSES = ['0.0.0.0', '::', '[::]'];
 
-/** Rejection details for a request that failed Host/Origin validation. */
 export interface HostValidationRejection {
   status: number;
   message: string;
 }
 
-/** True when `host` is a wildcard bind address (`0.0.0.0`, `::`). */
 export function isWildcardBindAddress(host: string | undefined): boolean {
   const normalized = normalizeHostname(host);
   return normalized !== undefined && WILDCARD_BIND_ADDRESSES.includes(normalized);
 }
 
-/**
- * Normalize a `Host`-header-style value (`example.com:3000`, `127.0.0.1`, `[::1]:3000`) to a
- * bare, lowercased hostname with the port stripped. Returns `undefined` if it cannot be parsed.
- *
- * Note that IPv6 comes back bracketed (`[::1]`), matching the SDK — an allowlist entry of `::1`
- * would never match, which is why callers should use the bracketed form.
- */
 export function normalizeHostname(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
@@ -57,8 +22,6 @@ export function normalizeHostname(value: string | undefined): string | undefined
   }
 
   const candidates = [trimmed];
-  // A bare IPv6 literal ('::1') is not a valid URL authority, but its bracketed form is. Accept
-  // both so `--host ::1` behaves the same as `--host [::1]`.
   if (!trimmed.startsWith('[') && (trimmed.match(/:/g)?.length ?? 0) > 1) {
     candidates.push(`[${trimmed}]`);
   }
@@ -76,7 +39,6 @@ export function normalizeHostname(value: string | undefined): string | undefined
   return undefined;
 }
 
-/** Parse the hostname out of an `Origin` header (a full origin such as `http://host:3000`). */
 function normalizeOriginHostname(origin: string): string | undefined {
   try {
     const { hostname } = new URL(origin.trim());
@@ -86,15 +48,6 @@ function normalizeOriginHostname(origin: string): string | undefined {
   }
 }
 
-/**
- * Build the list of hostnames this server accepts in the `Host` header.
- *
- * `override` is a comma-separated operator-supplied list (`DT_MCP_ALLOWED_HOSTS`) and wins
- * outright when set. Otherwise the list is derived from the bound host plus the loopback names.
- *
- * Returns an empty array to mean "cannot be determined" — bound to a wildcard address with no
- * override — which callers treat as validation disabled.
- */
 export function buildAllowedHostnames(boundHost: string | undefined, override?: string): string[] {
   const fromOverride = (override ?? '')
     .split(',')
@@ -109,23 +62,14 @@ export function buildAllowedHostnames(boundHost: string | undefined, override?: 
   }
 
   const bound = normalizeHostname(boundHost);
-  // Loopback names are safe to include even for a LAN bind: `Host` is derived from the URL the
-  // browser was pointed at, so an attacker cannot keep their own origin while sending `localhost`.
   return [...new Set([...(bound ? [bound] : []), ...LOOPBACK_HOSTNAMES])];
 }
 
-/** Truncate attacker-controlled header values before they reach a response body or the log. */
 function forDisplay(value: string): string {
   const collapsed = value.replace(/[\r\n]+/g, ' ').trim();
   return collapsed.length > 100 ? `${collapsed.slice(0, 100)}...` : collapsed;
 }
 
-/**
- * Validate the `Host` and `Origin` headers of an incoming request.
- *
- * Returns `undefined` when the request is acceptable, or the rejection to send back. An empty
- * `allowedHostnames` disables validation entirely (wildcard bind with no operator allowlist).
- */
 export function validateRequestHeaders(
   hostHeader: string | undefined,
   originHeader: string | undefined,
@@ -146,9 +90,6 @@ export function validateRequestHeaders(
     return { status: 403, message: `Invalid Host: ${forDisplay(hostname)}` };
   }
 
-  // Second layer. Non-browser MCP clients do not send `Origin`, so an absent one is normal and
-  // allowed. A browser always sends it, and a DNS-rebound page still carries the attacker's
-  // origin — so rejecting unknown origins blocks the attack independently of the Host check.
   if (originHeader !== undefined && originHeader.trim() !== '') {
     const originHostname = normalizeOriginHostname(originHeader);
     if (!originHostname || !allowedHostnames.includes(originHostname)) {

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -48,17 +48,25 @@ function normalizeOriginHostname(origin: string): string | undefined {
   }
 }
 
-export function buildAllowedHostnames(boundHost: string | undefined, override?: string): string[] {
-  const fromOverride = (override ?? '')
+function parseAllowlistOverride(override: string | undefined): string[] {
+  return (override ?? '')
     .split(',')
     .map((entry) => normalizeHostname(entry))
     .filter((entry): entry is string => entry !== undefined);
+}
+
+export function hasExplicitAllowlist(override: string | undefined): boolean {
+  return parseAllowlistOverride(override).length > 0;
+}
+
+export function buildAllowedHostnames(boundHost: string | undefined, override?: string): string[] {
+  const fromOverride = parseAllowlistOverride(override);
   if (fromOverride.length > 0) {
     return [...new Set(fromOverride)];
   }
 
   if (isWildcardBindAddress(boundHost)) {
-    return [];
+    return [...LOOPBACK_HOSTNAMES];
   }
 
   const bound = normalizeHostname(boundHost);
@@ -76,7 +84,7 @@ export function validateRequestHeaders(
   allowedHostnames: string[],
 ): HostValidationRejection | undefined {
   if (allowedHostnames.length === 0) {
-    return undefined;
+    return { status: 403, message: 'Host validation is not configured' };
   }
 
   if (!hostHeader || hostHeader.trim() === '') {

--- a/src/utils/host-validation.ts
+++ b/src/utils/host-validation.ts
@@ -1,6 +1,6 @@
 const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
-const WILDCARD_BIND_ADDRESSES = ['0.0.0.0', '::', '[::]'];
+const WILDCARD_BIND_ADDRESSES = new Set(['0.0.0.0', '::', '[::]']);
 
 export interface HostValidationRejection {
   status: number;
@@ -9,7 +9,7 @@ export interface HostValidationRejection {
 
 export function isWildcardBindAddress(host: string | undefined): boolean {
   const normalized = normalizeHostname(host);
-  return normalized !== undefined && WILDCARD_BIND_ADDRESSES.includes(normalized);
+  return normalized !== undefined && WILDCARD_BIND_ADDRESSES.has(normalized);
 }
 
 export function normalizeHostname(value: string | undefined): string | undefined {
@@ -59,18 +59,18 @@ export function hasExplicitAllowlist(override: string | undefined): boolean {
   return parseAllowlistOverride(override).length > 0;
 }
 
-export function buildAllowedHostnames(boundHost: string | undefined, override?: string): string[] {
+export function buildAllowedHostnames(boundHost: string | undefined, override?: string): ReadonlySet<string> {
   const fromOverride = parseAllowlistOverride(override);
   if (fromOverride.length > 0) {
-    return [...new Set(fromOverride)];
+    return new Set(fromOverride);
   }
 
   if (isWildcardBindAddress(boundHost)) {
-    return [...LOOPBACK_HOSTNAMES];
+    return new Set(LOOPBACK_HOSTNAMES);
   }
 
   const bound = normalizeHostname(boundHost);
-  return [...new Set([...(bound ? [bound] : []), ...LOOPBACK_HOSTNAMES])];
+  return new Set([...(bound ? [bound] : []), ...LOOPBACK_HOSTNAMES]);
 }
 
 function forDisplay(value: string): string {
@@ -81,9 +81,9 @@ function forDisplay(value: string): string {
 export function validateRequestHeaders(
   hostHeader: string | undefined,
   originHeader: string | undefined,
-  allowedHostnames: string[],
+  allowedHostnames: ReadonlySet<string>,
 ): HostValidationRejection | undefined {
-  if (allowedHostnames.length === 0) {
+  if (allowedHostnames.size === 0) {
     return { status: 403, message: 'Host validation is not configured' };
   }
 
@@ -94,13 +94,13 @@ export function validateRequestHeaders(
   if (!hostname) {
     return { status: 403, message: `Invalid Host header: ${forDisplay(hostHeader)}` };
   }
-  if (!allowedHostnames.includes(hostname)) {
+  if (!allowedHostnames.has(hostname)) {
     return { status: 403, message: `Invalid Host: ${forDisplay(hostname)}` };
   }
 
   if (originHeader !== undefined && originHeader.trim() !== '') {
     const originHostname = normalizeOriginHostname(originHeader);
-    if (!originHostname || !allowedHostnames.includes(originHostname)) {
+    if (!originHostname || !allowedHostnames.has(originHostname)) {
       return { status: 403, message: `Invalid Origin: ${forDisplay(originHeader)}` };
     }
   }


### PR DESCRIPTION
This PR fixes the vulnerability in HTTP mode of DNS rebinding by validating Host and Origin (if exists). When the host is declared as '0.0.0.0' (or '::') only: "localhost", "127.0.0.1" and "[::1]" unless the DT_MCP_ALLOWED_HOSTS variable is set with the list of accepted hosts. If the host doesn't get validated, the 403 Forbidden error is returned.