### PR TITLE
NOISSUE(bugfix): apply status filter via problemSelector in list_problems

### DIFF
--- a/src/capabilities/__tests__/problems-api.test.ts
+++ b/src/capabilities/__tests__/problems-api.test.ts
@@ -42,7 +42,7 @@ describe('ProblemsApiClient', () => {
           pageSize: 25,
           from: 'now-24h',
           to: 'now',
-          status: 'OPEN',
+          problemSelector: 'status("OPEN")',
           impactLevel: 'SERVICE',
           sort: '-startTime',
         },

--- a/src/capabilities/problems-api.ts
+++ b/src/capabilities/problems-api.ts
@@ -79,7 +79,7 @@ export class ProblemsApiClient {
       pageSize: params.pageSize || ProblemsApiClient.API_PAGE_SIZE,
       ...(params.from && { from: params.from }),
       ...(params.to && { to: params.to }),
-      ...(params.status && { status: params.status }),
+      ...(params.status && { problemSelector: `status("${params.status}")` }),
       ...(params.impactLevel && { impactLevel: params.impactLevel }),
       ...(params.entitySelector && { entitySelector: params.entitySelector }),
       ...(params.sort && { sort: params.sort }),


### PR DESCRIPTION
The `dynatrace_managed_list_problems` tool accepted a `status` argument (`OPEN`/`CLOSED`) but it had no effect — problems of all statuses were returned regardless.

The Problems API v2 has no top-level `status` query parameter; status must be expressed through `problemSelector`. The code sent a bare `status=OPEN` param, which Dynatrace silently ignores.

Fix mirrors the sibling security-problems API, which already builds `securityProblemSelector: status("...")`.

Validated against a live Managed environment:
- Before: `?status=OPEN` → 13 problems (CLOSED=12, OPEN=1) — filter ignored
- After: `?problemSelector=status("OPEN")` → 1 problem (OPEN=1) — correctly filtered