### PR TITLE
Apply status filter via problem selector in list problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Fixed status filter not being applies in `list_problems` tool by @jasssonpet
+- Fixed status filter not being applied in `list_problems` tool - @jasssonpet
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Malformed aliases will no longer be printed in logs. Instead, alias index will be printed to point which alias is wrong
 
+### Fixes
+
+- Fixed status filter not being applies in `list_problems` tool by @jasssonpet
+
 ## 1.0.1
 
 ### Dependencies

--- a/src/capabilities/__tests__/problems-api.test.ts
+++ b/src/capabilities/__tests__/problems-api.test.ts
@@ -42,7 +42,7 @@ describe('ProblemsApiClient', () => {
           pageSize: 25,
           from: 'now-24h',
           to: 'now',
-          status: 'OPEN',
+          problemSelector: 'status("OPEN")',
           impactLevel: 'SERVICE',
           sort: '-startTime',
         },

--- a/src/capabilities/problems-api.ts
+++ b/src/capabilities/problems-api.ts
@@ -79,7 +79,7 @@ export class ProblemsApiClient {
       pageSize: params.pageSize || ProblemsApiClient.API_PAGE_SIZE,
       ...(params.from && { from: params.from }),
       ...(params.to && { to: params.to }),
-      ...(params.status && { status: params.status }),
+      ...(params.status && { problemSelector: `status("${params.status}")` }),
       ...(params.impactLevel && { impactLevel: params.impactLevel }),
       ...(params.entitySelector && { entitySelector: params.entitySelector }),
       ...(params.sort && { sort: params.sort }),


### PR DESCRIPTION
Merged from https://github.com/dynatrace-oss/dynatrace-managed-mcp/pull/236
This PR also adds changelog and contributor mention, but mainly this PR is created from this repo to ensure SNYK analysis can run (secrets are not shared in forked repositories).