### PR TITLE
PRISM-9376 - publish the mcp to cursor directory catalog

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "dynatrace-managed-mcp",
+  "displayName": "Dynatrace Managed",
+  "version": "1.1.1",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Query logs, metrics, events, entities, problems, security vulnerabilities and SLOs from self-hosted Dynatrace Managed clusters, across one or many environments.",
+  "author": {
+    "name": "Dynatrace",
+    "url": "https://www.dynatrace.com"
+  },
+  "homepage": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
+  "repository": "https://github.com/dynatrace-oss/dynatrace-managed-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["dynatrace", "dynatrace-managed", "mcp", "observability", "monitoring", "apm", "logs", "metrics", "slo"],
+  "category": "integrations",
+  "tags": ["dynatrace", "observability", "monitoring", "apm", "mcp"],
+  "variables": {
+    "type": "object",
+    "properties": {
+      "DT_ENVIRONMENT_CONFIGS": {
+        "type": "string",
+        "title": "Dynatrace Managed environments",
+        "description": "JSON array of the clusters to connect to, each with alias, apiEndpointUrl, environmentId and apiToken. Example: [{\"alias\":\"production\",\"apiEndpointUrl\":\"https://dynatrace.example.com/e/<env-id>/api\",\"environmentId\":\"<env-id>\",\"apiToken\":\"dt0c01....\"}]. See docs/api_token_scopes.md for the read-only scopes the token needs. For multi-cluster setups you can instead set DT_CONFIG_FILE to a JSON or YAML file."
+      },
+      "LOG_LEVEL": {
+        "type": "string",
+        "title": "Log level",
+        "description": "Optional. One of debug, info, warning or error. Defaults to info."
+      }
+    },
+    "required": ["DT_ENVIRONMENT_CONFIGS"]
+  },
+  "skills": "./skills/",
+  "mcpServers": "./mcp.json"
+}

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -11,7 +11,9 @@ When preparing a release, follow these steps to ensure everything is in order:
 3. Work on a release branch, typically named `chore/prepare-release-<version>`.
 4. Create a new section in CHANGELOG.md for the version below "Unreleased Changes".
 5. Move all entries from "Unreleased Changes" to this new section.
-6. Update the version number in `package.json`, `server.json`, and `gemini-extension.json`.
+6. Update the version number in `package.json`, `server.json` (both `version` and `packages[].version`),
+   and `plugin.json`. `mcp.json` has no version field and needs no change.
 7. Run `npm install --package-lock-only` to sync the lock file.
-8. Let the user verify the release notes and version number before proceeding.
-9. Commit the changes with a message like `chore(release): prepare for <version> release`.
+8. Run `npm run version:check` to confirm every manifest agrees. See [RELEASE.md](../../RELEASE.md).
+9. Let the user verify the release notes and version number before proceeding.
+10. Commit the changes with a message like `chore(release): prepare for <version> release`.

--- a/.github/scripts/check-version-sync.js
+++ b/.github/scripts/check-version-sync.js
@@ -1,0 +1,139 @@
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const AGENT_PLUGINS_SPEC_VERSION = '1.0.0';
+
+function readJson(relativePath) {
+  const absolutePath = path.join(REPO_ROOT, relativePath);
+  try {
+    return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not read ${relativePath}: ${error.message}`);
+  }
+}
+
+function npmPackageFromNpxArgs(server) {
+  if (server.command !== 'npx' || !Array.isArray(server.args)) {
+    return undefined;
+  }
+
+  const packageSpec = server.args.find((arg) => !arg.startsWith('-'));
+  if (!packageSpec) {
+    return undefined;
+  }
+
+  const versionSeparator = packageSpec.lastIndexOf('@');
+  return versionSeparator > 0 ? packageSpec.slice(0, versionSeparator) : packageSpec;
+}
+
+function collectVersions(pkg, serverManifest, pluginManifest) {
+  const versions = [
+    { source: 'package.json » version', value: pkg.version },
+    { source: 'server.json » version', value: serverManifest.version },
+    { source: 'plugin.json » version', value: pluginManifest.version },
+  ];
+
+  (serverManifest.packages || []).forEach((entry, index) => {
+    versions.push({ source: `server.json » packages[${index}].version`, value: entry.version });
+  });
+
+  return versions;
+}
+
+function collectIdentifiers(pkg, serverManifest, mcpManifest) {
+  const identifiers = [{ source: 'package.json » name', value: pkg.name }];
+
+  (serverManifest.packages || []).forEach((entry, index) => {
+    if (entry.registryType === 'npm') {
+      identifiers.push({ source: `server.json » packages[${index}].identifier`, value: entry.identifier });
+    }
+  });
+
+  Object.entries(mcpManifest.mcpServers || {}).forEach(([serverName, server]) => {
+    const identifier = npmPackageFromNpxArgs(server);
+    if (identifier) {
+      identifiers.push({ source: `mcp.json » mcpServers.${serverName}.args`, value: identifier });
+    }
+  });
+
+  return identifiers;
+}
+
+function findDisagreements(label, entries) {
+  const [reference, ...rest] = entries;
+  const mismatches = rest.filter((entry) => entry.value !== reference.value);
+
+  if (mismatches.length === 0) {
+    return [];
+  }
+
+  return [
+    `${label} is out of sync - expected "${reference.value}" (from ${reference.source}):\n` +
+      mismatches.map((entry) => `    ${entry.source} = ${JSON.stringify(entry.value)}`).join('\n'),
+  ];
+}
+
+function checkAgentPluginsSchemas(pluginManifest, mcpManifest) {
+  const expected = {
+    'plugin.json': `https://agent-plugins.org/schemas/${AGENT_PLUGINS_SPEC_VERSION}/plugin.schema.json`,
+    'mcp.json': `https://agent-plugins.org/schemas/${AGENT_PLUGINS_SPEC_VERSION}/mcp.schema.json`,
+  };
+  const actual = { 'plugin.json': pluginManifest.$schema, 'mcp.json': mcpManifest.$schema };
+
+  return Object.entries(expected)
+    .filter(([file, url]) => actual[file] !== url)
+    .map(([file, url]) => `${file} » $schema must be "${url}" but is ${JSON.stringify(actual[file])}`);
+}
+
+function parseExpectedVersion(argv) {
+  const flagIndex = argv.indexOf('--expect-version');
+  if (flagIndex === -1) {
+    return undefined;
+  }
+
+  const value = argv[flagIndex + 1];
+  if (!value || value.startsWith('-')) {
+    console.error('❌ --expect-version requires a value, e.g. --expect-version 1.2.0');
+    process.exit(1);
+  }
+
+  return value;
+}
+
+function main() {
+  const expectedVersion = parseExpectedVersion(process.argv.slice(2));
+  const pkg = readJson('package.json');
+  const serverManifest = readJson('server.json');
+  const pluginManifest = readJson('plugin.json');
+  const mcpManifest = readJson('mcp.json');
+
+  const errors = [
+    ...findDisagreements('Package version', collectVersions(pkg, serverManifest, pluginManifest)),
+    ...findDisagreements('Package identifier', collectIdentifiers(pkg, serverManifest, mcpManifest)),
+    ...findDisagreements('MCP registry name', [
+      { source: 'package.json » mcpName', value: pkg.mcpName },
+      { source: 'server.json » name', value: serverManifest.name },
+    ]),
+    ...checkAgentPluginsSchemas(pluginManifest, mcpManifest),
+  ];
+
+  if (expectedVersion !== undefined && pkg.version !== expectedVersion) {
+    errors.push(
+      `Released version "${expectedVersion}" does not match the manifests, which declare ` +
+        `"${pkg.version}". Bump the manifests or retag.`,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error('❌ Manifests are inconsistent:\n');
+    errors.forEach((error) => console.error(`  - ${error}\n`));
+    console.error('Update every manifest listed in RELEASE.md before tagging.');
+    process.exit(1);
+  }
+
+  const suffix = expectedVersion === undefined ? '' : ` (matching released version ${expectedVersion})`;
+  console.log(`✅ Manifests agree: version ${pkg.version}, package ${pkg.name}, mcpName ${pkg.mcpName}${suffix}.`);
+}
+
+main();

--- a/.github/scripts/check-version-sync.js
+++ b/.github/scripts/check-version-sync.js
@@ -31,11 +31,12 @@ function lockRootPackage(lock) {
   return (lock.packages || {})[''] || {};
 }
 
-function collectVersions(pkg, lock, serverManifest, pluginManifest) {
+function collectVersions(pkg, lock, serverManifest, pluginManifest, cursorManifest) {
   const versions = [
     { source: 'package.json » version', value: pkg.version },
     { source: 'server.json » version', value: serverManifest.version },
     { source: 'plugin.json » version', value: pluginManifest.version },
+    { source: '.cursor-plugin/plugin.json » version', value: cursorManifest.version },
     { source: 'package-lock.json » version', value: lock.version },
     { source: 'package-lock.json » packages[""].version', value: lockRootPackage(lock).version },
   ];
@@ -45,6 +46,13 @@ function collectVersions(pkg, lock, serverManifest, pluginManifest) {
   });
 
   return versions;
+}
+
+function collectPluginNames(pluginManifest, cursorManifest) {
+  return [
+    { source: 'plugin.json » name', value: pluginManifest.name },
+    { source: '.cursor-plugin/plugin.json » name', value: cursorManifest.name },
+  ];
 }
 
 function collectIdentifiers(pkg, lock, serverManifest, mcpManifest) {
@@ -96,6 +104,40 @@ function checkAgentPluginsSchemas(pluginManifest, mcpManifest) {
     .map(([file, url]) => `${file} » $schema must be "${url}" but is ${JSON.stringify(actual[file])}`);
 }
 
+function checkCursorManifestPaths(cursorManifest) {
+  const declaredPaths = { skills: cursorManifest.skills, mcpServers: cursorManifest.mcpServers };
+
+  return Object.entries(declaredPaths)
+    .filter(([, declared]) => declared && !fs.existsSync(path.join(REPO_ROOT, declared)))
+    .map(([field, declared]) => `.cursor-plugin/plugin.json » ${field} points at "${declared}", which does not exist`);
+}
+
+function checkCursorVariablesAreWired(cursorManifest, mcpManifest) {
+  const declared = Object.keys((cursorManifest.variables || {}).properties || {});
+  const referenced = new Set();
+
+  Object.values(mcpManifest.mcpServers || {}).forEach((server) => {
+    Object.values(server.env || {}).forEach((value) => {
+      const match = /^\$\{(.+)\}$/.exec(value);
+      if (match) {
+        referenced.add(match[1]);
+      }
+    });
+  });
+
+  const required = ((cursorManifest.variables || {}).required || []).filter((name) => !referenced.has(name));
+  const orphaned = [...referenced].filter((name) => !declared.includes(name));
+
+  return [
+    ...required.map(
+      (name) => `.cursor-plugin/plugin.json requires variable "${name}" but no mcp.json server env references it`,
+    ),
+    ...orphaned.map(
+      (name) => `mcp.json references \${${name}} but .cursor-plugin/plugin.json declares no such variable`,
+    ),
+  ];
+}
+
 function parseExpectedVersion(argv) {
   const flagIndex = argv.indexOf('--expect-version');
   if (flagIndex === -1) {
@@ -117,16 +159,20 @@ function main() {
   const lock = readJson('package-lock.json');
   const serverManifest = readJson('server.json');
   const pluginManifest = readJson('plugin.json');
+  const cursorManifest = readJson('.cursor-plugin/plugin.json');
   const mcpManifest = readJson('mcp.json');
 
   const errors = [
-    ...findDisagreements('Package version', collectVersions(pkg, lock, serverManifest, pluginManifest)),
+    ...findDisagreements('Package version', collectVersions(pkg, lock, serverManifest, pluginManifest, cursorManifest)),
     ...findDisagreements('Package identifier', collectIdentifiers(pkg, lock, serverManifest, mcpManifest)),
+    ...findDisagreements('Plugin name', collectPluginNames(pluginManifest, cursorManifest)),
     ...findDisagreements('MCP registry name', [
       { source: 'package.json » mcpName', value: pkg.mcpName },
       { source: 'server.json » name', value: serverManifest.name },
     ]),
     ...checkAgentPluginsSchemas(pluginManifest, mcpManifest),
+    ...checkCursorManifestPaths(cursorManifest),
+    ...checkCursorVariablesAreWired(cursorManifest, mcpManifest),
   ];
 
   if (expectedVersion !== undefined && pkg.version !== expectedVersion) {

--- a/.github/scripts/check-version-sync.js
+++ b/.github/scripts/check-version-sync.js
@@ -27,11 +27,17 @@ function npmPackageFromNpxArgs(server) {
   return versionSeparator > 0 ? packageSpec.slice(0, versionSeparator) : packageSpec;
 }
 
-function collectVersions(pkg, serverManifest, pluginManifest) {
+function lockRootPackage(lock) {
+  return (lock.packages || {})[''] || {};
+}
+
+function collectVersions(pkg, lock, serverManifest, pluginManifest) {
   const versions = [
     { source: 'package.json » version', value: pkg.version },
     { source: 'server.json » version', value: serverManifest.version },
     { source: 'plugin.json » version', value: pluginManifest.version },
+    { source: 'package-lock.json » version', value: lock.version },
+    { source: 'package-lock.json » packages[""].version', value: lockRootPackage(lock).version },
   ];
 
   (serverManifest.packages || []).forEach((entry, index) => {
@@ -41,8 +47,12 @@ function collectVersions(pkg, serverManifest, pluginManifest) {
   return versions;
 }
 
-function collectIdentifiers(pkg, serverManifest, mcpManifest) {
-  const identifiers = [{ source: 'package.json » name', value: pkg.name }];
+function collectIdentifiers(pkg, lock, serverManifest, mcpManifest) {
+  const identifiers = [
+    { source: 'package.json » name', value: pkg.name },
+    { source: 'package-lock.json » name', value: lock.name },
+    { source: 'package-lock.json » packages[""].name', value: lockRootPackage(lock).name },
+  ];
 
   (serverManifest.packages || []).forEach((entry, index) => {
     if (entry.registryType === 'npm') {
@@ -104,13 +114,14 @@ function parseExpectedVersion(argv) {
 function main() {
   const expectedVersion = parseExpectedVersion(process.argv.slice(2));
   const pkg = readJson('package.json');
+  const lock = readJson('package-lock.json');
   const serverManifest = readJson('server.json');
   const pluginManifest = readJson('plugin.json');
   const mcpManifest = readJson('mcp.json');
 
   const errors = [
-    ...findDisagreements('Package version', collectVersions(pkg, serverManifest, pluginManifest)),
-    ...findDisagreements('Package identifier', collectIdentifiers(pkg, serverManifest, mcpManifest)),
+    ...findDisagreements('Package version', collectVersions(pkg, lock, serverManifest, pluginManifest)),
+    ...findDisagreements('Package identifier', collectIdentifiers(pkg, lock, serverManifest, mcpManifest)),
     ...findDisagreements('MCP registry name', [
       { source: 'package.json » mcpName', value: pkg.mcpName },
       { source: 'server.json » name', value: serverManifest.name },
@@ -129,6 +140,7 @@ function main() {
     console.error('❌ Manifests are inconsistent:\n');
     errors.forEach((error) => console.error(`  - ${error}\n`));
     console.error('Update every manifest listed in RELEASE.md before tagging.');
+    console.error('A stale package-lock.json is fixed with `npm install --package-lock-only`.');
     process.exit(1);
   }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Prettier
         run: npm run prettier
 
+      - name: Check manifest version sync
+        run: npm run version:check
+
       - name: Run tests with coverage
         run: npm run test:unit -- --coverage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run prettier
         run: npm run prettier
 
+      - name: Check manifest version sync
+        run: npm run version:check
+
       - name: Run tests
         run: npm run test:unit
 
@@ -58,6 +61,14 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Use Node.js # will read version from .nvmrc
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Verify tag matches manifest versions
+        run: npm run version:check -- --expect-version "${{ steps.version.outputs.version }}"
 
       - name: Extract changelog for GitHub Release
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @dynatrace-oss/dynatrace-managed-mcp
 
+## Unreleased Changes
+
+### Features
+
+- Added Agent Plugins v1.0.0 packaging so the server can be installed from the Cursor plugin directory and other plugin hosts: `plugin.json` (plugin manifest), `mcp.json` (MCP server definition) and a `dynatrace-managed` skill under `skills/`
+
+### Changes
+
+- Added `npm run version:check`, which asserts that `package.json`, `server.json` and `plugin.json` declare the same version and that `mcp.json` points at the published npm package. It runs on every pull request and gates the release workflow, including a check that the pushed tag matches the manifests
+
+### Documentation
+
+- Documented the version-bearing manifests and the `version:check` gate in [RELEASE.md](RELEASE.md)
+
 ## 1.1.1
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-- Added `npm run version:check`, which asserts that `package.json`, `server.json` and `plugin.json` declare the same version and that `mcp.json` points at the published npm package. It runs on every pull request and gates the release workflow, including a check that the pushed tag matches the manifests
+- Added `npm run version:check`, which asserts that `package.json`, `package-lock.json`, `server.json` and `plugin.json` declare the same version and package name, and that `mcp.json` points at the published npm package. It runs on every pull request and gates the release workflow, including a check that the pushed tag matches the manifests
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features
 
-- Added Agent Plugins v1.0.0 packaging so the server can be installed from the Cursor plugin directory and other plugin hosts: `plugin.json` (plugin manifest), `mcp.json` (MCP server definition) and a `dynatrace-managed` skill under `skills/`
+- Added plugin packaging so the server can be installed from the Cursor plugin directory and other plugin hosts: `.cursor-plugin/plugin.json` (Cursor manifest, including a `variables` block that prompts for `DT_ENVIRONMENT_CONFIGS` on install), `plugin.json` (portable Agent Plugins v1.0.0 manifest), `mcp.json` (MCP server definition, pinned to the current major) and a `dynatrace-managed` skill under `skills/`
 
 ### Changes
 
-- Added `npm run version:check`, which asserts that `package.json`, `package-lock.json`, `server.json` and `plugin.json` declare the same version and package name, and that `mcp.json` points at the published npm package. It runs on every pull request and gates the release workflow, including a check that the pushed tag matches the manifests
+- Added `npm run version:check`, which asserts that `package.json`, `package-lock.json`, `server.json`, `plugin.json` and `.cursor-plugin/plugin.json` declare the same version and package name, that `mcp.json` points at the published npm package, and that the Cursor manifest's declared paths and required variables are wired up. It runs on every pull request and gates the release workflow, including a check that the pushed tag matches the manifests
 
 ### Documentation
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,18 +9,23 @@ This repository uses automated GitHub workflows to prepare releases whenever a n
 
 ## Version-bearing manifests
 
-The npm package version is declared in four places, and they must all agree before tagging:
+The npm package version is declared in four files, and they must all agree before tagging:
 
-| File           | Field(s)                        |
-| -------------- | ------------------------------- |
-| `package.json` | `version`                       |
-| `server.json`  | `version`, `packages[].version` |
-| `plugin.json`  | `version`                       |
+| File                | Field(s)                          |
+| ------------------- | --------------------------------- |
+| `package.json`      | `version`                         |
+| `package-lock.json` | `version`, `packages[""].version` |
+| `server.json`       | `version`, `packages[].version`   |
+| `plugin.json`       | `version`                         |
+
+`package-lock.json` is refreshed with `npm install --package-lock-only` after bumping
+`package.json`. Note that `npm ci` succeeds against a stale root version and does not correct it, so
+the lock file is only kept honest by this check.
 
 `mcp.json` carries no version of its own - the Agent Plugins schema has no such field, and the `npx`
 invocation is deliberately left unpinned so directory installs pick up the latest published release.
-What it does carry is the npm package identifier, which must match `package.json` » `name` and
-`server.json` » `packages[].identifier`.
+What it does carry is the npm package identifier, which must match `package.json`,
+`package-lock.json` and `server.json` » `packages[].identifier`.
 
 `npm run version:check` asserts all of the above. It runs on every pull request, again at the start of
 the release workflow, and once more against the pushed tag - so a tag that disagrees with the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,23 +9,31 @@ This repository uses automated GitHub workflows to prepare releases whenever a n
 
 ## Version-bearing manifests
 
-The npm package version is declared in four files, and they must all agree before tagging:
+The npm package version is declared in five files, and they must all agree before tagging:
 
-| File                | Field(s)                          |
-| ------------------- | --------------------------------- |
-| `package.json`      | `version`                         |
-| `package-lock.json` | `version`, `packages[""].version` |
-| `server.json`       | `version`, `packages[].version`   |
-| `plugin.json`       | `version`                         |
+| File                         | Field(s)                          |
+| ---------------------------- | --------------------------------- |
+| `package.json`               | `version`                         |
+| `package-lock.json`          | `version`, `packages[""].version` |
+| `server.json`                | `version`, `packages[].version`   |
+| `plugin.json`                | `version`                         |
+| `.cursor-plugin/plugin.json` | `version`                         |
 
 `package-lock.json` is refreshed with `npm install --package-lock-only` after bumping
 `package.json`. Note that `npm ci` succeeds against a stale root version and does not correct it, so
 the lock file is only kept honest by this check.
 
-`mcp.json` carries no version of its own - the Agent Plugins schema has no such field, and the `npx`
-invocation is deliberately left unpinned so directory installs pick up the latest published release.
-What it does carry is the npm package identifier, which must match `package.json`,
-`package-lock.json` and `server.json` » `packages[].identifier`.
+`mcp.json` carries no version of its own - the Agent Plugins schema has no such field. Its `npx`
+invocation pins only the major (`@<2`), so plugin installs pick up patches and minors automatically
+but never an unvetted breaking major; widen that range deliberately when releasing a new major. The
+package identifier it does carry must match `package.json`, `package-lock.json` and `server.json` »
+`packages[].identifier`.
+
+`npm run version:check` additionally asserts that the two plugin manifests agree on `name`, that the
+`skills` and `mcpServers` paths in `.cursor-plugin/plugin.json` resolve to real files, and that every
+variable the Cursor manifest marks `required` is actually referenced as `${...}` by an `mcp.json`
+server - a required variable nothing reads is never prompted for, and a placeholder with no matching
+variable reaches the server unexpanded.
 
 `npm run version:check` asserts all of the above. It runs on every pull request, again at the start of
 the release workflow, and once more against the pushed tag - so a tag that disagrees with the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,29 @@ This repository uses automated GitHub workflows to prepare releases whenever a n
 1. When you push a tag starting with `v` (e.g., `v1.0.0`, `v2.1.3`), the release workflow automatically triggers
 2. The workflow builds the project, runs tests, and creates a GitHub release with release notes extracted from [CHANGELOG.md](CHANGELOG.md) file
 
+## Version-bearing manifests
+
+The npm package version is declared in four places, and they must all agree before tagging:
+
+| File           | Field(s)                        |
+| -------------- | ------------------------------- |
+| `package.json` | `version`                       |
+| `server.json`  | `version`, `packages[].version` |
+| `plugin.json`  | `version`                       |
+
+`mcp.json` carries no version of its own - the Agent Plugins schema has no such field, and the `npx`
+invocation is deliberately left unpinned so directory installs pick up the latest published release.
+What it does carry is the npm package identifier, which must match `package.json` » `name` and
+`server.json` » `packages[].identifier`.
+
+`npm run version:check` asserts all of the above. It runs on every pull request, again at the start of
+the release workflow, and once more against the pushed tag - so a tag that disagrees with the
+manifests fails before anything is published to npm, GHCR or the MCP Registry.
+
+```bash
+npm run version:check
+```
+
 ## Creating a Release
 
 ### Manual tagging

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "dynatrace-managed": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@dynatrace-oss/dynatrace-managed-mcp-server"]
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -4,7 +4,10 @@
     "dynatrace-managed": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@dynatrace-oss/dynatrace-managed-mcp-server"]
+      "args": ["-y", "@dynatrace-oss/dynatrace-managed-mcp-server@<2"],
+      "env": {
+        "DT_ENVIRONMENT_CONFIGS": "${DT_ENVIRONMENT_CONFIGS}"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "coverage": "jest --coverage",
     "serve": "node --env-file='.env' ./dist/index.js --http --port 8080",
     "stdio": "node --env-file='.env' ./dist/index.js",
+    "version:check": "node .github/scripts/check-version-sync.js",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write ."
   },

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "dynatrace-managed-mcp",
+  "version": "1.1.1",
+  "description": "MCP server for Dynatrace Managed (self-hosted): query logs, metrics, events, entities, problems, security vulnerabilities and SLOs across one or more clusters.",
+  "author": {
+    "name": "Dynatrace",
+    "url": "https://www.dynatrace.com"
+  },
+  "homepage": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
+  "repository": "https://github.com/dynatrace-oss/dynatrace-managed-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["dynatrace", "dynatrace-managed", "mcp", "observability", "monitoring", "apm", "logs", "metrics", "slo"]
+}

--- a/skills/dynatrace-managed/SKILL.md
+++ b/skills/dynatrace-managed/SKILL.md
@@ -19,7 +19,9 @@ The server exits at startup unless exactly one configuration source is present. 
 with `Configuration not found`, or `dynatrace_managed_get_environments_info` reports configuration
 errors, the user needs to supply credentials - no amount of retrying will fix it.
 
-Two mutually exclusive options, in priority order:
+When installed as a plugin, the client prompts for `DT_ENVIRONMENT_CONFIGS` up front and injects it
+into the server, so this is usually already handled. Outside that flow there are two mutually
+exclusive options, in priority order:
 
 1. **`DT_CONFIG_FILE`** - path to a JSON or YAML file describing the environments. Preferred for more
    than one cluster. Write `apiToken: ${DT_PROD_TOKEN}` and the loader interpolates that variable at

--- a/skills/dynatrace-managed/SKILL.md
+++ b/skills/dynatrace-managed/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: dynatrace-managed
+description: Set up and query Dynatrace Managed (self-hosted) through the Dynatrace Managed MCP server - configuring cluster connections and API tokens, choosing the right environment when several are configured, and building entity selectors for logs, metrics, events, problems, security vulnerabilities and SLOs. Use when the user mentions Dynatrace, Dynatrace Managed, observability data for their services, or when a dynatrace_managed_* tool returns a configuration or connection error.
+license: Apache-2.0
+compatibility: Requires Node.js and network access to a Dynatrace Managed cluster API endpoint.
+metadata:
+  author: dynatrace-oss
+---
+
+# Dynatrace Managed
+
+Guidance for driving the `dynatrace-managed` MCP server. The server sends its own detailed tool
+instructions on connect - this skill covers what it cannot: getting it configured, and adapting
+queries to this repository's own components and tagging strategy.
+
+## First: is it configured?
+
+The server exits at startup unless exactly one configuration source is present. If tool calls fail
+with `Configuration not found`, or `dynatrace_managed_get_environments_info` reports configuration
+errors, the user needs to supply credentials - no amount of retrying will fix it.
+
+Two mutually exclusive options, in priority order:
+
+1. **`DT_CONFIG_FILE`** - path to a JSON or YAML file describing the environments. Preferred for more
+   than one cluster. Write `apiToken: ${DT_PROD_TOKEN}` and the loader interpolates that variable at
+   runtime, so the file itself stays free of secrets and can be committed.
+2. **`DT_ENVIRONMENT_CONFIGS`** - a JSON array as a single environment variable. Preferred for one
+   cluster and for containerized setups.
+
+Setting both logs a warning and `DT_CONFIG_FILE` wins.
+
+Minimal `DT_ENVIRONMENT_CONFIGS` value:
+
+```json
+[
+  {
+    "alias": "production",
+    "apiEndpointUrl": "https://dynatrace.example.com/e/abc12345-1234-1234-1234-123456789abc/api",
+    "environmentId": "abc12345-1234-1234-1234-123456789abc",
+    "apiToken": "dt0c01...."
+  }
+]
+```
+
+The API token needs read-only scopes. Point the user at
+[docs/api_token_scopes.md](https://github.com/dynatrace-oss/dynatrace-managed-mcp/blob/main/docs/api_token_scopes.md)
+rather than guessing which scopes a given tool requires, and at
+[docs/environment_variables.md](https://github.com/dynatrace-oss/dynatrace-managed-mcp/blob/main/docs/environment_variables.md)
+for the full variable list.
+
+Never write a real API token into a file that is tracked by git, and never echo one back in chat.
+
+## Always start with the environment list
+
+Call `dynatrace_managed_get_environments_info` before any other tool. It returns the configured
+aliases along with per-environment connection and configuration errors. **Report those errors to the
+user before doing anything else** - a partially reachable cluster produces silently incomplete
+answers.
+
+Every subsequent tool call takes an `environment_alias`. Use `ALL_ENVIRONMENTS` only when the user
+genuinely wants every cluster fanned out; it multiplies load on self-hosted infrastructure.
+
+## Picking the right environment
+
+Two ambiguities cause most wrong answers here:
+
+- **Managed vs. SaaS.** A user may have this server _and_ a Dynatrace SaaS MCP server configured at
+  once. These are different backends with different data. If it is not obvious which one the question
+  is about, ask. Some organizations have migrated to SaaS and keep Dynatrace Managed only as a
+  historical archive - in that case live questions belong to SaaS.
+- **Which cluster.** Refer to environments by the `alias` from the configuration, and state in the
+  answer which environment the data came from. Do not average or merge results across environments
+  without saying so.
+
+## Keeping queries cheap
+
+Dynatrace Managed is self-hosted, so an expensive query degrades the user's own cluster.
+
+- Use narrow relative time ranges: `now-1h`, `now-24h`. Reach for `now-7d` or wider only when the
+  question is explicitly historical.
+- Filter at the source with an `entitySelector` instead of retrieving broadly and post-filtering.
+- When the user names a count ("the first 25 errors"), set `limit` - do not approximate with
+  `searchText`.
+- Use problem IDs in UUID form from `dynatrace_managed_list_problems`, not the `P-XXXXX` display IDs.
+
+## Entity selectors
+
+`dynatrace_managed_discover_entities` always requires an `entitySelector`, and a selector may name
+**exactly one** entity type. Comma-separated criteria are ANDed.
+
+```text
+type("SERVICE"),entityName.contains("checkout")
+type("SERVICE"),tag("environment:production"),tag("app:checkout")
+type("HOST"),healthState("HEALTHY"),mzName("Production")
+type("AWS_LAMBDA_FUNCTION"),tag("AWS_REGION:us-west-2")
+entityId("SERVICE-123","SERVICE-456")
+```
+
+Invalid, and worth recognizing before the API rejects them:
+
+```text
+type(SERVICE),type(PROCESS_GROUP)        # only one type per query
+entityName("my-service")                 # type() required unless entityId() is used
+entityId("ID1") or entityId("ID2")       # no OR; pass both IDs to one entityId()
+```
+
+### Adapt this to the repository
+
+Replace the placeholders below with the components and tags actually in use, and keep the list next
+to whatever else describes this system. A selector tuned to real tags is the single biggest quality
+win available here.
+
+```text
+Services:         type("SERVICE"),tag("app:<your-app>")
+Process groups:   type("PROCESS_GROUP"),entityName.contains("<your-app>")
+Containers:       type("CONTAINER_GROUP_INSTANCE"),entityName.contains("<your-app>")
+Hosts:            type("HOST"),tag("environment:production"),tag("app:<your-app>")
+```
+
+If the tagging strategy is unknown, discover it first with
+`dynatrace_managed_list_entity_types` and `dynatrace_managed_get_entity_type_details` rather than
+inventing tag keys.
+
+## Log queries
+
+Simple form: a case-insensitive text search, e.g. `error`.
+
+Structured form, which can be combined with `AND`:
+
+```text
+content="error" AND dt.entity.host="HOST-94A1B472D04D89D9"
+```
+
+## Workflows
+
+| Goal                   | Sequence                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Incident investigation | `list_problems` -> `get_problem_details`                                                                                        |
+| Security assessment    | `list_security_problems` -> `get_security_problem_details`                                                                      |
+| SLO / error budget     | `list_slos` -> `get_slo_details`                                                                                                |
+| Entity exploration     | `list_entity_types` -> `discover_entities` -> `get_entity_details` -> `list_problems` or `list_events` scoped by that entity ID |
+
+All tool names carry the `dynatrace_managed_` prefix. Each response ends with a `Next Steps` footer -
+read it, it names the tool that usefully follows.


### PR DESCRIPTION
This PR adds files required by Open Plugins standard (which Cursor follows) to be able to publish the plugin on Cursor directory. The requirements include: mcp.json, plugin.json, SKILL.md.  Open Plugins standard: https://agent-plugins.org/
It also adds verification if the MCP version matches across: package.json, package-lock.json, server.json, plugin.json and .cursor-plugin/plugin.json. The verification is attached to the gh actions.
Cursor directory: https://cursor.directory/